### PR TITLE
introduce mapArgX(WithRepresentation)

### DIFF
--- a/src/main/generated/kotlin/com/tegonal/minimalist/Args1.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/Args1.kt
@@ -38,6 +38,28 @@ interface Args1<A1>: Args {
 	 */
 	fun withArg1(value: A1, representation: String? = null): Args1<A1>
 
+	/**
+	 * Maps [a1] of this [Args1] with the given [transform] function resulting in a new [Args1].
+	 *
+	 * @param transform The function which maps [a1] to a new value.
+	 *
+	 * @return The newly created [Args1].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1(transform: (A1) -> A1New): Args1<A1New>
+
+	/**
+	 * Maps [a1] and its [representation1] of this [Args1] with the given [transform] function resulting in a new [Args1].
+	 *
+	 * @param transform The function which maps [a1] and [representation1].
+	 *
+	 * @return The newly created [Args1].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1WithRepresentation(transform: (A1, String?) -> Pair<A1New, String?>): Args1<A1New>
+
 
 	/**
 	 * Creates a new [Args2] by copying `this` [Args1] and appending the given [Args1].

--- a/src/main/generated/kotlin/com/tegonal/minimalist/Args10.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/Args10.kt
@@ -147,6 +147,28 @@ interface Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>: Args {
 	fun withArg1(value: A1, representation: String? = null): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>
 
 	/**
+	 * Maps [a1] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a1] to a new value.
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1(transform: (A1) -> A1New): Args10<A1New, A2, A3, A4, A5, A6, A7, A8, A9, A10>
+
+	/**
+	 * Maps [a1] and its [representation1] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a1] and [representation1].
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1WithRepresentation(transform: (A1, String?) -> Pair<A1New, String?>): Args10<A1New, A2, A3, A4, A5, A6, A7, A8, A9, A10>
+
+	/**
 	 * Creates a new [Args10] by coping `this` [Args10] but replaces
 	 * the argument 2 ([Args10.a2]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -159,6 +181,28 @@ interface Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg2(value: A2, representation: String? = null): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>
+
+	/**
+	 * Maps [a2] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a2] to a new value.
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2(transform: (A2) -> A2New): Args10<A1, A2New, A3, A4, A5, A6, A7, A8, A9, A10>
+
+	/**
+	 * Maps [a2] and its [representation2] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a2] and [representation2].
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2WithRepresentation(transform: (A2, String?) -> Pair<A2New, String?>): Args10<A1, A2New, A3, A4, A5, A6, A7, A8, A9, A10>
 
 	/**
 	 * Creates a new [Args10] by coping `this` [Args10] but replaces
@@ -175,6 +219,28 @@ interface Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>: Args {
 	fun withArg3(value: A3, representation: String? = null): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>
 
 	/**
+	 * Maps [a3] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a3] to a new value.
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A3New> mapArg3(transform: (A3) -> A3New): Args10<A1, A2, A3New, A4, A5, A6, A7, A8, A9, A10>
+
+	/**
+	 * Maps [a3] and its [representation3] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a3] and [representation3].
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A3New> mapArg3WithRepresentation(transform: (A3, String?) -> Pair<A3New, String?>): Args10<A1, A2, A3New, A4, A5, A6, A7, A8, A9, A10>
+
+	/**
 	 * Creates a new [Args10] by coping `this` [Args10] but replaces
 	 * the argument 4 ([Args10.a4]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -187,6 +253,28 @@ interface Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg4(value: A4, representation: String? = null): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>
+
+	/**
+	 * Maps [a4] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a4] to a new value.
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A4New> mapArg4(transform: (A4) -> A4New): Args10<A1, A2, A3, A4New, A5, A6, A7, A8, A9, A10>
+
+	/**
+	 * Maps [a4] and its [representation4] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a4] and [representation4].
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A4New> mapArg4WithRepresentation(transform: (A4, String?) -> Pair<A4New, String?>): Args10<A1, A2, A3, A4New, A5, A6, A7, A8, A9, A10>
 
 	/**
 	 * Creates a new [Args10] by coping `this` [Args10] but replaces
@@ -203,6 +291,28 @@ interface Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>: Args {
 	fun withArg5(value: A5, representation: String? = null): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>
 
 	/**
+	 * Maps [a5] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a5] to a new value.
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A5New> mapArg5(transform: (A5) -> A5New): Args10<A1, A2, A3, A4, A5New, A6, A7, A8, A9, A10>
+
+	/**
+	 * Maps [a5] and its [representation5] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a5] and [representation5].
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A5New> mapArg5WithRepresentation(transform: (A5, String?) -> Pair<A5New, String?>): Args10<A1, A2, A3, A4, A5New, A6, A7, A8, A9, A10>
+
+	/**
 	 * Creates a new [Args10] by coping `this` [Args10] but replaces
 	 * the argument 6 ([Args10.a6]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -215,6 +325,28 @@ interface Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg6(value: A6, representation: String? = null): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>
+
+	/**
+	 * Maps [a6] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a6] to a new value.
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A6New> mapArg6(transform: (A6) -> A6New): Args10<A1, A2, A3, A4, A5, A6New, A7, A8, A9, A10>
+
+	/**
+	 * Maps [a6] and its [representation6] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a6] and [representation6].
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A6New> mapArg6WithRepresentation(transform: (A6, String?) -> Pair<A6New, String?>): Args10<A1, A2, A3, A4, A5, A6New, A7, A8, A9, A10>
 
 	/**
 	 * Creates a new [Args10] by coping `this` [Args10] but replaces
@@ -231,6 +363,28 @@ interface Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>: Args {
 	fun withArg7(value: A7, representation: String? = null): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>
 
 	/**
+	 * Maps [a7] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a7] to a new value.
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A7New> mapArg7(transform: (A7) -> A7New): Args10<A1, A2, A3, A4, A5, A6, A7New, A8, A9, A10>
+
+	/**
+	 * Maps [a7] and its [representation7] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a7] and [representation7].
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A7New> mapArg7WithRepresentation(transform: (A7, String?) -> Pair<A7New, String?>): Args10<A1, A2, A3, A4, A5, A6, A7New, A8, A9, A10>
+
+	/**
 	 * Creates a new [Args10] by coping `this` [Args10] but replaces
 	 * the argument 8 ([Args10.a8]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -243,6 +397,28 @@ interface Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg8(value: A8, representation: String? = null): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>
+
+	/**
+	 * Maps [a8] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a8] to a new value.
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A8New> mapArg8(transform: (A8) -> A8New): Args10<A1, A2, A3, A4, A5, A6, A7, A8New, A9, A10>
+
+	/**
+	 * Maps [a8] and its [representation8] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a8] and [representation8].
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A8New> mapArg8WithRepresentation(transform: (A8, String?) -> Pair<A8New, String?>): Args10<A1, A2, A3, A4, A5, A6, A7, A8New, A9, A10>
 
 	/**
 	 * Creates a new [Args10] by coping `this` [Args10] but replaces
@@ -259,6 +435,28 @@ interface Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>: Args {
 	fun withArg9(value: A9, representation: String? = null): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>
 
 	/**
+	 * Maps [a9] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a9] to a new value.
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A9New> mapArg9(transform: (A9) -> A9New): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9New, A10>
+
+	/**
+	 * Maps [a9] and its [representation9] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a9] and [representation9].
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A9New> mapArg9WithRepresentation(transform: (A9, String?) -> Pair<A9New, String?>): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9New, A10>
+
+	/**
 	 * Creates a new [Args10] by coping `this` [Args10] but replaces
 	 * the argument 10 ([Args10.a10]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -271,6 +469,28 @@ interface Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg10(value: A10, representation: String? = null): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>
+
+	/**
+	 * Maps [a10] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a10] to a new value.
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A10New> mapArg10(transform: (A10) -> A10New): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10New>
+
+	/**
+	 * Maps [a10] and its [representation10] of this [Args10] with the given [transform] function resulting in a new [Args10].
+	 *
+	 * @param transform The function which maps [a10] and [representation10].
+	 *
+	 * @return The newly created [Args10].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A10New> mapArg10WithRepresentation(transform: (A10, String?) -> Pair<A10New, String?>): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10New>
 
 
 	/**

--- a/src/main/generated/kotlin/com/tegonal/minimalist/Args2.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/Args2.kt
@@ -51,6 +51,28 @@ interface Args2<A1, A2>: Args {
 	fun withArg1(value: A1, representation: String? = null): Args2<A1, A2>
 
 	/**
+	 * Maps [a1] of this [Args2] with the given [transform] function resulting in a new [Args2].
+	 *
+	 * @param transform The function which maps [a1] to a new value.
+	 *
+	 * @return The newly created [Args2].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1(transform: (A1) -> A1New): Args2<A1New, A2>
+
+	/**
+	 * Maps [a1] and its [representation1] of this [Args2] with the given [transform] function resulting in a new [Args2].
+	 *
+	 * @param transform The function which maps [a1] and [representation1].
+	 *
+	 * @return The newly created [Args2].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1WithRepresentation(transform: (A1, String?) -> Pair<A1New, String?>): Args2<A1New, A2>
+
+	/**
 	 * Creates a new [Args2] by coping `this` [Args2] but replaces
 	 * the argument 2 ([Args2.a2]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -63,6 +85,28 @@ interface Args2<A1, A2>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg2(value: A2, representation: String? = null): Args2<A1, A2>
+
+	/**
+	 * Maps [a2] of this [Args2] with the given [transform] function resulting in a new [Args2].
+	 *
+	 * @param transform The function which maps [a2] to a new value.
+	 *
+	 * @return The newly created [Args2].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2(transform: (A2) -> A2New): Args2<A1, A2New>
+
+	/**
+	 * Maps [a2] and its [representation2] of this [Args2] with the given [transform] function resulting in a new [Args2].
+	 *
+	 * @param transform The function which maps [a2] and [representation2].
+	 *
+	 * @return The newly created [Args2].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2WithRepresentation(transform: (A2, String?) -> Pair<A2New, String?>): Args2<A1, A2New>
 
 
 	/**

--- a/src/main/generated/kotlin/com/tegonal/minimalist/Args3.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/Args3.kt
@@ -63,6 +63,28 @@ interface Args3<A1, A2, A3>: Args {
 	fun withArg1(value: A1, representation: String? = null): Args3<A1, A2, A3>
 
 	/**
+	 * Maps [a1] of this [Args3] with the given [transform] function resulting in a new [Args3].
+	 *
+	 * @param transform The function which maps [a1] to a new value.
+	 *
+	 * @return The newly created [Args3].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1(transform: (A1) -> A1New): Args3<A1New, A2, A3>
+
+	/**
+	 * Maps [a1] and its [representation1] of this [Args3] with the given [transform] function resulting in a new [Args3].
+	 *
+	 * @param transform The function which maps [a1] and [representation1].
+	 *
+	 * @return The newly created [Args3].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1WithRepresentation(transform: (A1, String?) -> Pair<A1New, String?>): Args3<A1New, A2, A3>
+
+	/**
 	 * Creates a new [Args3] by coping `this` [Args3] but replaces
 	 * the argument 2 ([Args3.a2]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -77,6 +99,28 @@ interface Args3<A1, A2, A3>: Args {
 	fun withArg2(value: A2, representation: String? = null): Args3<A1, A2, A3>
 
 	/**
+	 * Maps [a2] of this [Args3] with the given [transform] function resulting in a new [Args3].
+	 *
+	 * @param transform The function which maps [a2] to a new value.
+	 *
+	 * @return The newly created [Args3].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2(transform: (A2) -> A2New): Args3<A1, A2New, A3>
+
+	/**
+	 * Maps [a2] and its [representation2] of this [Args3] with the given [transform] function resulting in a new [Args3].
+	 *
+	 * @param transform The function which maps [a2] and [representation2].
+	 *
+	 * @return The newly created [Args3].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2WithRepresentation(transform: (A2, String?) -> Pair<A2New, String?>): Args3<A1, A2New, A3>
+
+	/**
 	 * Creates a new [Args3] by coping `this` [Args3] but replaces
 	 * the argument 3 ([Args3.a3]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -89,6 +133,28 @@ interface Args3<A1, A2, A3>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg3(value: A3, representation: String? = null): Args3<A1, A2, A3>
+
+	/**
+	 * Maps [a3] of this [Args3] with the given [transform] function resulting in a new [Args3].
+	 *
+	 * @param transform The function which maps [a3] to a new value.
+	 *
+	 * @return The newly created [Args3].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A3New> mapArg3(transform: (A3) -> A3New): Args3<A1, A2, A3New>
+
+	/**
+	 * Maps [a3] and its [representation3] of this [Args3] with the given [transform] function resulting in a new [Args3].
+	 *
+	 * @param transform The function which maps [a3] and [representation3].
+	 *
+	 * @return The newly created [Args3].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A3New> mapArg3WithRepresentation(transform: (A3, String?) -> Pair<A3New, String?>): Args3<A1, A2, A3New>
 
 
 	/**

--- a/src/main/generated/kotlin/com/tegonal/minimalist/Args4.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/Args4.kt
@@ -75,6 +75,28 @@ interface Args4<A1, A2, A3, A4>: Args {
 	fun withArg1(value: A1, representation: String? = null): Args4<A1, A2, A3, A4>
 
 	/**
+	 * Maps [a1] of this [Args4] with the given [transform] function resulting in a new [Args4].
+	 *
+	 * @param transform The function which maps [a1] to a new value.
+	 *
+	 * @return The newly created [Args4].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1(transform: (A1) -> A1New): Args4<A1New, A2, A3, A4>
+
+	/**
+	 * Maps [a1] and its [representation1] of this [Args4] with the given [transform] function resulting in a new [Args4].
+	 *
+	 * @param transform The function which maps [a1] and [representation1].
+	 *
+	 * @return The newly created [Args4].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1WithRepresentation(transform: (A1, String?) -> Pair<A1New, String?>): Args4<A1New, A2, A3, A4>
+
+	/**
 	 * Creates a new [Args4] by coping `this` [Args4] but replaces
 	 * the argument 2 ([Args4.a2]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -87,6 +109,28 @@ interface Args4<A1, A2, A3, A4>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg2(value: A2, representation: String? = null): Args4<A1, A2, A3, A4>
+
+	/**
+	 * Maps [a2] of this [Args4] with the given [transform] function resulting in a new [Args4].
+	 *
+	 * @param transform The function which maps [a2] to a new value.
+	 *
+	 * @return The newly created [Args4].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2(transform: (A2) -> A2New): Args4<A1, A2New, A3, A4>
+
+	/**
+	 * Maps [a2] and its [representation2] of this [Args4] with the given [transform] function resulting in a new [Args4].
+	 *
+	 * @param transform The function which maps [a2] and [representation2].
+	 *
+	 * @return The newly created [Args4].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2WithRepresentation(transform: (A2, String?) -> Pair<A2New, String?>): Args4<A1, A2New, A3, A4>
 
 	/**
 	 * Creates a new [Args4] by coping `this` [Args4] but replaces
@@ -103,6 +147,28 @@ interface Args4<A1, A2, A3, A4>: Args {
 	fun withArg3(value: A3, representation: String? = null): Args4<A1, A2, A3, A4>
 
 	/**
+	 * Maps [a3] of this [Args4] with the given [transform] function resulting in a new [Args4].
+	 *
+	 * @param transform The function which maps [a3] to a new value.
+	 *
+	 * @return The newly created [Args4].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A3New> mapArg3(transform: (A3) -> A3New): Args4<A1, A2, A3New, A4>
+
+	/**
+	 * Maps [a3] and its [representation3] of this [Args4] with the given [transform] function resulting in a new [Args4].
+	 *
+	 * @param transform The function which maps [a3] and [representation3].
+	 *
+	 * @return The newly created [Args4].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A3New> mapArg3WithRepresentation(transform: (A3, String?) -> Pair<A3New, String?>): Args4<A1, A2, A3New, A4>
+
+	/**
 	 * Creates a new [Args4] by coping `this` [Args4] but replaces
 	 * the argument 4 ([Args4.a4]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -115,6 +181,28 @@ interface Args4<A1, A2, A3, A4>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg4(value: A4, representation: String? = null): Args4<A1, A2, A3, A4>
+
+	/**
+	 * Maps [a4] of this [Args4] with the given [transform] function resulting in a new [Args4].
+	 *
+	 * @param transform The function which maps [a4] to a new value.
+	 *
+	 * @return The newly created [Args4].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A4New> mapArg4(transform: (A4) -> A4New): Args4<A1, A2, A3, A4New>
+
+	/**
+	 * Maps [a4] and its [representation4] of this [Args4] with the given [transform] function resulting in a new [Args4].
+	 *
+	 * @param transform The function which maps [a4] and [representation4].
+	 *
+	 * @return The newly created [Args4].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A4New> mapArg4WithRepresentation(transform: (A4, String?) -> Pair<A4New, String?>): Args4<A1, A2, A3, A4New>
 
 
 	/**

--- a/src/main/generated/kotlin/com/tegonal/minimalist/Args5.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/Args5.kt
@@ -87,6 +87,28 @@ interface Args5<A1, A2, A3, A4, A5>: Args {
 	fun withArg1(value: A1, representation: String? = null): Args5<A1, A2, A3, A4, A5>
 
 	/**
+	 * Maps [a1] of this [Args5] with the given [transform] function resulting in a new [Args5].
+	 *
+	 * @param transform The function which maps [a1] to a new value.
+	 *
+	 * @return The newly created [Args5].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1(transform: (A1) -> A1New): Args5<A1New, A2, A3, A4, A5>
+
+	/**
+	 * Maps [a1] and its [representation1] of this [Args5] with the given [transform] function resulting in a new [Args5].
+	 *
+	 * @param transform The function which maps [a1] and [representation1].
+	 *
+	 * @return The newly created [Args5].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1WithRepresentation(transform: (A1, String?) -> Pair<A1New, String?>): Args5<A1New, A2, A3, A4, A5>
+
+	/**
 	 * Creates a new [Args5] by coping `this` [Args5] but replaces
 	 * the argument 2 ([Args5.a2]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -99,6 +121,28 @@ interface Args5<A1, A2, A3, A4, A5>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg2(value: A2, representation: String? = null): Args5<A1, A2, A3, A4, A5>
+
+	/**
+	 * Maps [a2] of this [Args5] with the given [transform] function resulting in a new [Args5].
+	 *
+	 * @param transform The function which maps [a2] to a new value.
+	 *
+	 * @return The newly created [Args5].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2(transform: (A2) -> A2New): Args5<A1, A2New, A3, A4, A5>
+
+	/**
+	 * Maps [a2] and its [representation2] of this [Args5] with the given [transform] function resulting in a new [Args5].
+	 *
+	 * @param transform The function which maps [a2] and [representation2].
+	 *
+	 * @return The newly created [Args5].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2WithRepresentation(transform: (A2, String?) -> Pair<A2New, String?>): Args5<A1, A2New, A3, A4, A5>
 
 	/**
 	 * Creates a new [Args5] by coping `this` [Args5] but replaces
@@ -115,6 +159,28 @@ interface Args5<A1, A2, A3, A4, A5>: Args {
 	fun withArg3(value: A3, representation: String? = null): Args5<A1, A2, A3, A4, A5>
 
 	/**
+	 * Maps [a3] of this [Args5] with the given [transform] function resulting in a new [Args5].
+	 *
+	 * @param transform The function which maps [a3] to a new value.
+	 *
+	 * @return The newly created [Args5].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A3New> mapArg3(transform: (A3) -> A3New): Args5<A1, A2, A3New, A4, A5>
+
+	/**
+	 * Maps [a3] and its [representation3] of this [Args5] with the given [transform] function resulting in a new [Args5].
+	 *
+	 * @param transform The function which maps [a3] and [representation3].
+	 *
+	 * @return The newly created [Args5].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A3New> mapArg3WithRepresentation(transform: (A3, String?) -> Pair<A3New, String?>): Args5<A1, A2, A3New, A4, A5>
+
+	/**
 	 * Creates a new [Args5] by coping `this` [Args5] but replaces
 	 * the argument 4 ([Args5.a4]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -129,6 +195,28 @@ interface Args5<A1, A2, A3, A4, A5>: Args {
 	fun withArg4(value: A4, representation: String? = null): Args5<A1, A2, A3, A4, A5>
 
 	/**
+	 * Maps [a4] of this [Args5] with the given [transform] function resulting in a new [Args5].
+	 *
+	 * @param transform The function which maps [a4] to a new value.
+	 *
+	 * @return The newly created [Args5].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A4New> mapArg4(transform: (A4) -> A4New): Args5<A1, A2, A3, A4New, A5>
+
+	/**
+	 * Maps [a4] and its [representation4] of this [Args5] with the given [transform] function resulting in a new [Args5].
+	 *
+	 * @param transform The function which maps [a4] and [representation4].
+	 *
+	 * @return The newly created [Args5].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A4New> mapArg4WithRepresentation(transform: (A4, String?) -> Pair<A4New, String?>): Args5<A1, A2, A3, A4New, A5>
+
+	/**
 	 * Creates a new [Args5] by coping `this` [Args5] but replaces
 	 * the argument 5 ([Args5.a5]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -141,6 +229,28 @@ interface Args5<A1, A2, A3, A4, A5>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg5(value: A5, representation: String? = null): Args5<A1, A2, A3, A4, A5>
+
+	/**
+	 * Maps [a5] of this [Args5] with the given [transform] function resulting in a new [Args5].
+	 *
+	 * @param transform The function which maps [a5] to a new value.
+	 *
+	 * @return The newly created [Args5].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A5New> mapArg5(transform: (A5) -> A5New): Args5<A1, A2, A3, A4, A5New>
+
+	/**
+	 * Maps [a5] and its [representation5] of this [Args5] with the given [transform] function resulting in a new [Args5].
+	 *
+	 * @param transform The function which maps [a5] and [representation5].
+	 *
+	 * @return The newly created [Args5].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A5New> mapArg5WithRepresentation(transform: (A5, String?) -> Pair<A5New, String?>): Args5<A1, A2, A3, A4, A5New>
 
 
 	/**

--- a/src/main/generated/kotlin/com/tegonal/minimalist/Args6.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/Args6.kt
@@ -99,6 +99,28 @@ interface Args6<A1, A2, A3, A4, A5, A6>: Args {
 	fun withArg1(value: A1, representation: String? = null): Args6<A1, A2, A3, A4, A5, A6>
 
 	/**
+	 * Maps [a1] of this [Args6] with the given [transform] function resulting in a new [Args6].
+	 *
+	 * @param transform The function which maps [a1] to a new value.
+	 *
+	 * @return The newly created [Args6].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1(transform: (A1) -> A1New): Args6<A1New, A2, A3, A4, A5, A6>
+
+	/**
+	 * Maps [a1] and its [representation1] of this [Args6] with the given [transform] function resulting in a new [Args6].
+	 *
+	 * @param transform The function which maps [a1] and [representation1].
+	 *
+	 * @return The newly created [Args6].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1WithRepresentation(transform: (A1, String?) -> Pair<A1New, String?>): Args6<A1New, A2, A3, A4, A5, A6>
+
+	/**
 	 * Creates a new [Args6] by coping `this` [Args6] but replaces
 	 * the argument 2 ([Args6.a2]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -111,6 +133,28 @@ interface Args6<A1, A2, A3, A4, A5, A6>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg2(value: A2, representation: String? = null): Args6<A1, A2, A3, A4, A5, A6>
+
+	/**
+	 * Maps [a2] of this [Args6] with the given [transform] function resulting in a new [Args6].
+	 *
+	 * @param transform The function which maps [a2] to a new value.
+	 *
+	 * @return The newly created [Args6].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2(transform: (A2) -> A2New): Args6<A1, A2New, A3, A4, A5, A6>
+
+	/**
+	 * Maps [a2] and its [representation2] of this [Args6] with the given [transform] function resulting in a new [Args6].
+	 *
+	 * @param transform The function which maps [a2] and [representation2].
+	 *
+	 * @return The newly created [Args6].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2WithRepresentation(transform: (A2, String?) -> Pair<A2New, String?>): Args6<A1, A2New, A3, A4, A5, A6>
 
 	/**
 	 * Creates a new [Args6] by coping `this` [Args6] but replaces
@@ -127,6 +171,28 @@ interface Args6<A1, A2, A3, A4, A5, A6>: Args {
 	fun withArg3(value: A3, representation: String? = null): Args6<A1, A2, A3, A4, A5, A6>
 
 	/**
+	 * Maps [a3] of this [Args6] with the given [transform] function resulting in a new [Args6].
+	 *
+	 * @param transform The function which maps [a3] to a new value.
+	 *
+	 * @return The newly created [Args6].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A3New> mapArg3(transform: (A3) -> A3New): Args6<A1, A2, A3New, A4, A5, A6>
+
+	/**
+	 * Maps [a3] and its [representation3] of this [Args6] with the given [transform] function resulting in a new [Args6].
+	 *
+	 * @param transform The function which maps [a3] and [representation3].
+	 *
+	 * @return The newly created [Args6].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A3New> mapArg3WithRepresentation(transform: (A3, String?) -> Pair<A3New, String?>): Args6<A1, A2, A3New, A4, A5, A6>
+
+	/**
 	 * Creates a new [Args6] by coping `this` [Args6] but replaces
 	 * the argument 4 ([Args6.a4]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -139,6 +205,28 @@ interface Args6<A1, A2, A3, A4, A5, A6>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg4(value: A4, representation: String? = null): Args6<A1, A2, A3, A4, A5, A6>
+
+	/**
+	 * Maps [a4] of this [Args6] with the given [transform] function resulting in a new [Args6].
+	 *
+	 * @param transform The function which maps [a4] to a new value.
+	 *
+	 * @return The newly created [Args6].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A4New> mapArg4(transform: (A4) -> A4New): Args6<A1, A2, A3, A4New, A5, A6>
+
+	/**
+	 * Maps [a4] and its [representation4] of this [Args6] with the given [transform] function resulting in a new [Args6].
+	 *
+	 * @param transform The function which maps [a4] and [representation4].
+	 *
+	 * @return The newly created [Args6].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A4New> mapArg4WithRepresentation(transform: (A4, String?) -> Pair<A4New, String?>): Args6<A1, A2, A3, A4New, A5, A6>
 
 	/**
 	 * Creates a new [Args6] by coping `this` [Args6] but replaces
@@ -155,6 +243,28 @@ interface Args6<A1, A2, A3, A4, A5, A6>: Args {
 	fun withArg5(value: A5, representation: String? = null): Args6<A1, A2, A3, A4, A5, A6>
 
 	/**
+	 * Maps [a5] of this [Args6] with the given [transform] function resulting in a new [Args6].
+	 *
+	 * @param transform The function which maps [a5] to a new value.
+	 *
+	 * @return The newly created [Args6].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A5New> mapArg5(transform: (A5) -> A5New): Args6<A1, A2, A3, A4, A5New, A6>
+
+	/**
+	 * Maps [a5] and its [representation5] of this [Args6] with the given [transform] function resulting in a new [Args6].
+	 *
+	 * @param transform The function which maps [a5] and [representation5].
+	 *
+	 * @return The newly created [Args6].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A5New> mapArg5WithRepresentation(transform: (A5, String?) -> Pair<A5New, String?>): Args6<A1, A2, A3, A4, A5New, A6>
+
+	/**
 	 * Creates a new [Args6] by coping `this` [Args6] but replaces
 	 * the argument 6 ([Args6.a6]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -167,6 +277,28 @@ interface Args6<A1, A2, A3, A4, A5, A6>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg6(value: A6, representation: String? = null): Args6<A1, A2, A3, A4, A5, A6>
+
+	/**
+	 * Maps [a6] of this [Args6] with the given [transform] function resulting in a new [Args6].
+	 *
+	 * @param transform The function which maps [a6] to a new value.
+	 *
+	 * @return The newly created [Args6].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A6New> mapArg6(transform: (A6) -> A6New): Args6<A1, A2, A3, A4, A5, A6New>
+
+	/**
+	 * Maps [a6] and its [representation6] of this [Args6] with the given [transform] function resulting in a new [Args6].
+	 *
+	 * @param transform The function which maps [a6] and [representation6].
+	 *
+	 * @return The newly created [Args6].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A6New> mapArg6WithRepresentation(transform: (A6, String?) -> Pair<A6New, String?>): Args6<A1, A2, A3, A4, A5, A6New>
 
 
 	/**

--- a/src/main/generated/kotlin/com/tegonal/minimalist/Args7.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/Args7.kt
@@ -111,6 +111,28 @@ interface Args7<A1, A2, A3, A4, A5, A6, A7>: Args {
 	fun withArg1(value: A1, representation: String? = null): Args7<A1, A2, A3, A4, A5, A6, A7>
 
 	/**
+	 * Maps [a1] of this [Args7] with the given [transform] function resulting in a new [Args7].
+	 *
+	 * @param transform The function which maps [a1] to a new value.
+	 *
+	 * @return The newly created [Args7].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1(transform: (A1) -> A1New): Args7<A1New, A2, A3, A4, A5, A6, A7>
+
+	/**
+	 * Maps [a1] and its [representation1] of this [Args7] with the given [transform] function resulting in a new [Args7].
+	 *
+	 * @param transform The function which maps [a1] and [representation1].
+	 *
+	 * @return The newly created [Args7].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1WithRepresentation(transform: (A1, String?) -> Pair<A1New, String?>): Args7<A1New, A2, A3, A4, A5, A6, A7>
+
+	/**
 	 * Creates a new [Args7] by coping `this` [Args7] but replaces
 	 * the argument 2 ([Args7.a2]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -123,6 +145,28 @@ interface Args7<A1, A2, A3, A4, A5, A6, A7>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg2(value: A2, representation: String? = null): Args7<A1, A2, A3, A4, A5, A6, A7>
+
+	/**
+	 * Maps [a2] of this [Args7] with the given [transform] function resulting in a new [Args7].
+	 *
+	 * @param transform The function which maps [a2] to a new value.
+	 *
+	 * @return The newly created [Args7].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2(transform: (A2) -> A2New): Args7<A1, A2New, A3, A4, A5, A6, A7>
+
+	/**
+	 * Maps [a2] and its [representation2] of this [Args7] with the given [transform] function resulting in a new [Args7].
+	 *
+	 * @param transform The function which maps [a2] and [representation2].
+	 *
+	 * @return The newly created [Args7].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2WithRepresentation(transform: (A2, String?) -> Pair<A2New, String?>): Args7<A1, A2New, A3, A4, A5, A6, A7>
 
 	/**
 	 * Creates a new [Args7] by coping `this` [Args7] but replaces
@@ -139,6 +183,28 @@ interface Args7<A1, A2, A3, A4, A5, A6, A7>: Args {
 	fun withArg3(value: A3, representation: String? = null): Args7<A1, A2, A3, A4, A5, A6, A7>
 
 	/**
+	 * Maps [a3] of this [Args7] with the given [transform] function resulting in a new [Args7].
+	 *
+	 * @param transform The function which maps [a3] to a new value.
+	 *
+	 * @return The newly created [Args7].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A3New> mapArg3(transform: (A3) -> A3New): Args7<A1, A2, A3New, A4, A5, A6, A7>
+
+	/**
+	 * Maps [a3] and its [representation3] of this [Args7] with the given [transform] function resulting in a new [Args7].
+	 *
+	 * @param transform The function which maps [a3] and [representation3].
+	 *
+	 * @return The newly created [Args7].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A3New> mapArg3WithRepresentation(transform: (A3, String?) -> Pair<A3New, String?>): Args7<A1, A2, A3New, A4, A5, A6, A7>
+
+	/**
 	 * Creates a new [Args7] by coping `this` [Args7] but replaces
 	 * the argument 4 ([Args7.a4]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -151,6 +217,28 @@ interface Args7<A1, A2, A3, A4, A5, A6, A7>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg4(value: A4, representation: String? = null): Args7<A1, A2, A3, A4, A5, A6, A7>
+
+	/**
+	 * Maps [a4] of this [Args7] with the given [transform] function resulting in a new [Args7].
+	 *
+	 * @param transform The function which maps [a4] to a new value.
+	 *
+	 * @return The newly created [Args7].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A4New> mapArg4(transform: (A4) -> A4New): Args7<A1, A2, A3, A4New, A5, A6, A7>
+
+	/**
+	 * Maps [a4] and its [representation4] of this [Args7] with the given [transform] function resulting in a new [Args7].
+	 *
+	 * @param transform The function which maps [a4] and [representation4].
+	 *
+	 * @return The newly created [Args7].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A4New> mapArg4WithRepresentation(transform: (A4, String?) -> Pair<A4New, String?>): Args7<A1, A2, A3, A4New, A5, A6, A7>
 
 	/**
 	 * Creates a new [Args7] by coping `this` [Args7] but replaces
@@ -167,6 +255,28 @@ interface Args7<A1, A2, A3, A4, A5, A6, A7>: Args {
 	fun withArg5(value: A5, representation: String? = null): Args7<A1, A2, A3, A4, A5, A6, A7>
 
 	/**
+	 * Maps [a5] of this [Args7] with the given [transform] function resulting in a new [Args7].
+	 *
+	 * @param transform The function which maps [a5] to a new value.
+	 *
+	 * @return The newly created [Args7].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A5New> mapArg5(transform: (A5) -> A5New): Args7<A1, A2, A3, A4, A5New, A6, A7>
+
+	/**
+	 * Maps [a5] and its [representation5] of this [Args7] with the given [transform] function resulting in a new [Args7].
+	 *
+	 * @param transform The function which maps [a5] and [representation5].
+	 *
+	 * @return The newly created [Args7].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A5New> mapArg5WithRepresentation(transform: (A5, String?) -> Pair<A5New, String?>): Args7<A1, A2, A3, A4, A5New, A6, A7>
+
+	/**
 	 * Creates a new [Args7] by coping `this` [Args7] but replaces
 	 * the argument 6 ([Args7.a6]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -181,6 +291,28 @@ interface Args7<A1, A2, A3, A4, A5, A6, A7>: Args {
 	fun withArg6(value: A6, representation: String? = null): Args7<A1, A2, A3, A4, A5, A6, A7>
 
 	/**
+	 * Maps [a6] of this [Args7] with the given [transform] function resulting in a new [Args7].
+	 *
+	 * @param transform The function which maps [a6] to a new value.
+	 *
+	 * @return The newly created [Args7].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A6New> mapArg6(transform: (A6) -> A6New): Args7<A1, A2, A3, A4, A5, A6New, A7>
+
+	/**
+	 * Maps [a6] and its [representation6] of this [Args7] with the given [transform] function resulting in a new [Args7].
+	 *
+	 * @param transform The function which maps [a6] and [representation6].
+	 *
+	 * @return The newly created [Args7].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A6New> mapArg6WithRepresentation(transform: (A6, String?) -> Pair<A6New, String?>): Args7<A1, A2, A3, A4, A5, A6New, A7>
+
+	/**
 	 * Creates a new [Args7] by coping `this` [Args7] but replaces
 	 * the argument 7 ([Args7.a7]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -193,6 +325,28 @@ interface Args7<A1, A2, A3, A4, A5, A6, A7>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg7(value: A7, representation: String? = null): Args7<A1, A2, A3, A4, A5, A6, A7>
+
+	/**
+	 * Maps [a7] of this [Args7] with the given [transform] function resulting in a new [Args7].
+	 *
+	 * @param transform The function which maps [a7] to a new value.
+	 *
+	 * @return The newly created [Args7].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A7New> mapArg7(transform: (A7) -> A7New): Args7<A1, A2, A3, A4, A5, A6, A7New>
+
+	/**
+	 * Maps [a7] and its [representation7] of this [Args7] with the given [transform] function resulting in a new [Args7].
+	 *
+	 * @param transform The function which maps [a7] and [representation7].
+	 *
+	 * @return The newly created [Args7].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A7New> mapArg7WithRepresentation(transform: (A7, String?) -> Pair<A7New, String?>): Args7<A1, A2, A3, A4, A5, A6, A7New>
 
 
 	/**

--- a/src/main/generated/kotlin/com/tegonal/minimalist/Args8.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/Args8.kt
@@ -123,6 +123,28 @@ interface Args8<A1, A2, A3, A4, A5, A6, A7, A8>: Args {
 	fun withArg1(value: A1, representation: String? = null): Args8<A1, A2, A3, A4, A5, A6, A7, A8>
 
 	/**
+	 * Maps [a1] of this [Args8] with the given [transform] function resulting in a new [Args8].
+	 *
+	 * @param transform The function which maps [a1] to a new value.
+	 *
+	 * @return The newly created [Args8].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1(transform: (A1) -> A1New): Args8<A1New, A2, A3, A4, A5, A6, A7, A8>
+
+	/**
+	 * Maps [a1] and its [representation1] of this [Args8] with the given [transform] function resulting in a new [Args8].
+	 *
+	 * @param transform The function which maps [a1] and [representation1].
+	 *
+	 * @return The newly created [Args8].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1WithRepresentation(transform: (A1, String?) -> Pair<A1New, String?>): Args8<A1New, A2, A3, A4, A5, A6, A7, A8>
+
+	/**
 	 * Creates a new [Args8] by coping `this` [Args8] but replaces
 	 * the argument 2 ([Args8.a2]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -135,6 +157,28 @@ interface Args8<A1, A2, A3, A4, A5, A6, A7, A8>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg2(value: A2, representation: String? = null): Args8<A1, A2, A3, A4, A5, A6, A7, A8>
+
+	/**
+	 * Maps [a2] of this [Args8] with the given [transform] function resulting in a new [Args8].
+	 *
+	 * @param transform The function which maps [a2] to a new value.
+	 *
+	 * @return The newly created [Args8].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2(transform: (A2) -> A2New): Args8<A1, A2New, A3, A4, A5, A6, A7, A8>
+
+	/**
+	 * Maps [a2] and its [representation2] of this [Args8] with the given [transform] function resulting in a new [Args8].
+	 *
+	 * @param transform The function which maps [a2] and [representation2].
+	 *
+	 * @return The newly created [Args8].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2WithRepresentation(transform: (A2, String?) -> Pair<A2New, String?>): Args8<A1, A2New, A3, A4, A5, A6, A7, A8>
 
 	/**
 	 * Creates a new [Args8] by coping `this` [Args8] but replaces
@@ -151,6 +195,28 @@ interface Args8<A1, A2, A3, A4, A5, A6, A7, A8>: Args {
 	fun withArg3(value: A3, representation: String? = null): Args8<A1, A2, A3, A4, A5, A6, A7, A8>
 
 	/**
+	 * Maps [a3] of this [Args8] with the given [transform] function resulting in a new [Args8].
+	 *
+	 * @param transform The function which maps [a3] to a new value.
+	 *
+	 * @return The newly created [Args8].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A3New> mapArg3(transform: (A3) -> A3New): Args8<A1, A2, A3New, A4, A5, A6, A7, A8>
+
+	/**
+	 * Maps [a3] and its [representation3] of this [Args8] with the given [transform] function resulting in a new [Args8].
+	 *
+	 * @param transform The function which maps [a3] and [representation3].
+	 *
+	 * @return The newly created [Args8].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A3New> mapArg3WithRepresentation(transform: (A3, String?) -> Pair<A3New, String?>): Args8<A1, A2, A3New, A4, A5, A6, A7, A8>
+
+	/**
 	 * Creates a new [Args8] by coping `this` [Args8] but replaces
 	 * the argument 4 ([Args8.a4]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -163,6 +229,28 @@ interface Args8<A1, A2, A3, A4, A5, A6, A7, A8>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg4(value: A4, representation: String? = null): Args8<A1, A2, A3, A4, A5, A6, A7, A8>
+
+	/**
+	 * Maps [a4] of this [Args8] with the given [transform] function resulting in a new [Args8].
+	 *
+	 * @param transform The function which maps [a4] to a new value.
+	 *
+	 * @return The newly created [Args8].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A4New> mapArg4(transform: (A4) -> A4New): Args8<A1, A2, A3, A4New, A5, A6, A7, A8>
+
+	/**
+	 * Maps [a4] and its [representation4] of this [Args8] with the given [transform] function resulting in a new [Args8].
+	 *
+	 * @param transform The function which maps [a4] and [representation4].
+	 *
+	 * @return The newly created [Args8].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A4New> mapArg4WithRepresentation(transform: (A4, String?) -> Pair<A4New, String?>): Args8<A1, A2, A3, A4New, A5, A6, A7, A8>
 
 	/**
 	 * Creates a new [Args8] by coping `this` [Args8] but replaces
@@ -179,6 +267,28 @@ interface Args8<A1, A2, A3, A4, A5, A6, A7, A8>: Args {
 	fun withArg5(value: A5, representation: String? = null): Args8<A1, A2, A3, A4, A5, A6, A7, A8>
 
 	/**
+	 * Maps [a5] of this [Args8] with the given [transform] function resulting in a new [Args8].
+	 *
+	 * @param transform The function which maps [a5] to a new value.
+	 *
+	 * @return The newly created [Args8].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A5New> mapArg5(transform: (A5) -> A5New): Args8<A1, A2, A3, A4, A5New, A6, A7, A8>
+
+	/**
+	 * Maps [a5] and its [representation5] of this [Args8] with the given [transform] function resulting in a new [Args8].
+	 *
+	 * @param transform The function which maps [a5] and [representation5].
+	 *
+	 * @return The newly created [Args8].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A5New> mapArg5WithRepresentation(transform: (A5, String?) -> Pair<A5New, String?>): Args8<A1, A2, A3, A4, A5New, A6, A7, A8>
+
+	/**
 	 * Creates a new [Args8] by coping `this` [Args8] but replaces
 	 * the argument 6 ([Args8.a6]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -191,6 +301,28 @@ interface Args8<A1, A2, A3, A4, A5, A6, A7, A8>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg6(value: A6, representation: String? = null): Args8<A1, A2, A3, A4, A5, A6, A7, A8>
+
+	/**
+	 * Maps [a6] of this [Args8] with the given [transform] function resulting in a new [Args8].
+	 *
+	 * @param transform The function which maps [a6] to a new value.
+	 *
+	 * @return The newly created [Args8].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A6New> mapArg6(transform: (A6) -> A6New): Args8<A1, A2, A3, A4, A5, A6New, A7, A8>
+
+	/**
+	 * Maps [a6] and its [representation6] of this [Args8] with the given [transform] function resulting in a new [Args8].
+	 *
+	 * @param transform The function which maps [a6] and [representation6].
+	 *
+	 * @return The newly created [Args8].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A6New> mapArg6WithRepresentation(transform: (A6, String?) -> Pair<A6New, String?>): Args8<A1, A2, A3, A4, A5, A6New, A7, A8>
 
 	/**
 	 * Creates a new [Args8] by coping `this` [Args8] but replaces
@@ -207,6 +339,28 @@ interface Args8<A1, A2, A3, A4, A5, A6, A7, A8>: Args {
 	fun withArg7(value: A7, representation: String? = null): Args8<A1, A2, A3, A4, A5, A6, A7, A8>
 
 	/**
+	 * Maps [a7] of this [Args8] with the given [transform] function resulting in a new [Args8].
+	 *
+	 * @param transform The function which maps [a7] to a new value.
+	 *
+	 * @return The newly created [Args8].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A7New> mapArg7(transform: (A7) -> A7New): Args8<A1, A2, A3, A4, A5, A6, A7New, A8>
+
+	/**
+	 * Maps [a7] and its [representation7] of this [Args8] with the given [transform] function resulting in a new [Args8].
+	 *
+	 * @param transform The function which maps [a7] and [representation7].
+	 *
+	 * @return The newly created [Args8].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A7New> mapArg7WithRepresentation(transform: (A7, String?) -> Pair<A7New, String?>): Args8<A1, A2, A3, A4, A5, A6, A7New, A8>
+
+	/**
 	 * Creates a new [Args8] by coping `this` [Args8] but replaces
 	 * the argument 8 ([Args8.a8]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -219,6 +373,28 @@ interface Args8<A1, A2, A3, A4, A5, A6, A7, A8>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg8(value: A8, representation: String? = null): Args8<A1, A2, A3, A4, A5, A6, A7, A8>
+
+	/**
+	 * Maps [a8] of this [Args8] with the given [transform] function resulting in a new [Args8].
+	 *
+	 * @param transform The function which maps [a8] to a new value.
+	 *
+	 * @return The newly created [Args8].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A8New> mapArg8(transform: (A8) -> A8New): Args8<A1, A2, A3, A4, A5, A6, A7, A8New>
+
+	/**
+	 * Maps [a8] and its [representation8] of this [Args8] with the given [transform] function resulting in a new [Args8].
+	 *
+	 * @param transform The function which maps [a8] and [representation8].
+	 *
+	 * @return The newly created [Args8].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A8New> mapArg8WithRepresentation(transform: (A8, String?) -> Pair<A8New, String?>): Args8<A1, A2, A3, A4, A5, A6, A7, A8New>
 
 
 	/**

--- a/src/main/generated/kotlin/com/tegonal/minimalist/Args9.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/Args9.kt
@@ -135,6 +135,28 @@ interface Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>: Args {
 	fun withArg1(value: A1, representation: String? = null): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>
 
 	/**
+	 * Maps [a1] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a1] to a new value.
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1(transform: (A1) -> A1New): Args9<A1New, A2, A3, A4, A5, A6, A7, A8, A9>
+
+	/**
+	 * Maps [a1] and its [representation1] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a1] and [representation1].
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A1New> mapArg1WithRepresentation(transform: (A1, String?) -> Pair<A1New, String?>): Args9<A1New, A2, A3, A4, A5, A6, A7, A8, A9>
+
+	/**
 	 * Creates a new [Args9] by coping `this` [Args9] but replaces
 	 * the argument 2 ([Args9.a2]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -147,6 +169,28 @@ interface Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg2(value: A2, representation: String? = null): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>
+
+	/**
+	 * Maps [a2] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a2] to a new value.
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2(transform: (A2) -> A2New): Args9<A1, A2New, A3, A4, A5, A6, A7, A8, A9>
+
+	/**
+	 * Maps [a2] and its [representation2] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a2] and [representation2].
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A2New> mapArg2WithRepresentation(transform: (A2, String?) -> Pair<A2New, String?>): Args9<A1, A2New, A3, A4, A5, A6, A7, A8, A9>
 
 	/**
 	 * Creates a new [Args9] by coping `this` [Args9] but replaces
@@ -163,6 +207,28 @@ interface Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>: Args {
 	fun withArg3(value: A3, representation: String? = null): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>
 
 	/**
+	 * Maps [a3] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a3] to a new value.
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A3New> mapArg3(transform: (A3) -> A3New): Args9<A1, A2, A3New, A4, A5, A6, A7, A8, A9>
+
+	/**
+	 * Maps [a3] and its [representation3] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a3] and [representation3].
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A3New> mapArg3WithRepresentation(transform: (A3, String?) -> Pair<A3New, String?>): Args9<A1, A2, A3New, A4, A5, A6, A7, A8, A9>
+
+	/**
 	 * Creates a new [Args9] by coping `this` [Args9] but replaces
 	 * the argument 4 ([Args9.a4]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -175,6 +241,28 @@ interface Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg4(value: A4, representation: String? = null): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>
+
+	/**
+	 * Maps [a4] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a4] to a new value.
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A4New> mapArg4(transform: (A4) -> A4New): Args9<A1, A2, A3, A4New, A5, A6, A7, A8, A9>
+
+	/**
+	 * Maps [a4] and its [representation4] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a4] and [representation4].
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A4New> mapArg4WithRepresentation(transform: (A4, String?) -> Pair<A4New, String?>): Args9<A1, A2, A3, A4New, A5, A6, A7, A8, A9>
 
 	/**
 	 * Creates a new [Args9] by coping `this` [Args9] but replaces
@@ -191,6 +279,28 @@ interface Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>: Args {
 	fun withArg5(value: A5, representation: String? = null): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>
 
 	/**
+	 * Maps [a5] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a5] to a new value.
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A5New> mapArg5(transform: (A5) -> A5New): Args9<A1, A2, A3, A4, A5New, A6, A7, A8, A9>
+
+	/**
+	 * Maps [a5] and its [representation5] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a5] and [representation5].
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A5New> mapArg5WithRepresentation(transform: (A5, String?) -> Pair<A5New, String?>): Args9<A1, A2, A3, A4, A5New, A6, A7, A8, A9>
+
+	/**
 	 * Creates a new [Args9] by coping `this` [Args9] but replaces
 	 * the argument 6 ([Args9.a6]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -203,6 +313,28 @@ interface Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg6(value: A6, representation: String? = null): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>
+
+	/**
+	 * Maps [a6] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a6] to a new value.
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A6New> mapArg6(transform: (A6) -> A6New): Args9<A1, A2, A3, A4, A5, A6New, A7, A8, A9>
+
+	/**
+	 * Maps [a6] and its [representation6] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a6] and [representation6].
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A6New> mapArg6WithRepresentation(transform: (A6, String?) -> Pair<A6New, String?>): Args9<A1, A2, A3, A4, A5, A6New, A7, A8, A9>
 
 	/**
 	 * Creates a new [Args9] by coping `this` [Args9] but replaces
@@ -219,6 +351,28 @@ interface Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>: Args {
 	fun withArg7(value: A7, representation: String? = null): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>
 
 	/**
+	 * Maps [a7] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a7] to a new value.
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A7New> mapArg7(transform: (A7) -> A7New): Args9<A1, A2, A3, A4, A5, A6, A7New, A8, A9>
+
+	/**
+	 * Maps [a7] and its [representation7] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a7] and [representation7].
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A7New> mapArg7WithRepresentation(transform: (A7, String?) -> Pair<A7New, String?>): Args9<A1, A2, A3, A4, A5, A6, A7New, A8, A9>
+
+	/**
 	 * Creates a new [Args9] by coping `this` [Args9] but replaces
 	 * the argument 8 ([Args9.a8]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -233,6 +387,28 @@ interface Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>: Args {
 	fun withArg8(value: A8, representation: String? = null): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>
 
 	/**
+	 * Maps [a8] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a8] to a new value.
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A8New> mapArg8(transform: (A8) -> A8New): Args9<A1, A2, A3, A4, A5, A6, A7, A8New, A9>
+
+	/**
+	 * Maps [a8] and its [representation8] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a8] and [representation8].
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A8New> mapArg8WithRepresentation(transform: (A8, String?) -> Pair<A8New, String?>): Args9<A1, A2, A3, A4, A5, A6, A7, A8New, A9>
+
+	/**
 	 * Creates a new [Args9] by coping `this` [Args9] but replaces
 	 * the argument 9 ([Args9.a9]) with the given [value] (and its representation with the given [representation]).
 	 *
@@ -245,6 +421,28 @@ interface Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>: Args {
 	 * @since 1.0.0
 	 */
 	fun withArg9(value: A9, representation: String? = null): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9>
+
+	/**
+	 * Maps [a9] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a9] to a new value.
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A9New> mapArg9(transform: (A9) -> A9New): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9New>
+
+	/**
+	 * Maps [a9] and its [representation9] of this [Args9] with the given [transform] function resulting in a new [Args9].
+	 *
+	 * @param transform The function which maps [a9] and [representation9].
+	 *
+	 * @return The newly created [Args9].
+	 *
+	 * @since 2.0.0
+	 */
+	fun <A9New> mapArg9WithRepresentation(transform: (A9, String?) -> Pair<A9New, String?>): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9New>
 
 
 	/**

--- a/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs1.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs1.kt
@@ -28,6 +28,21 @@ internal data class DefaultArgs1<A1>(
 	override fun withArg1(value: A1, representation: String?): Args1<A1> =
 		this.copy(a1 = value, representation1 = representation)
 
+	override fun <A1New> mapArg1(
+		transform: (A1) -> A1New
+	): Args1<A1New> =
+		Args.of(
+			a1 = transform(a1)
+		)
+
+	override fun <A1New> mapArg1WithRepresentation(
+		transform: (A1, String?) -> Pair<A1New, String?>
+	): Args1<A1New> =
+       transform(a1, representation1).let{ (newA1, newRepresentation1) ->
+			Args.of(
+				a1 = newA1, representation1 = newRepresentation1?.let { r -> Representation(r) }
+			)
+		}
 
 	override fun <A2> append(
 		args: Args1<A2>

--- a/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs10.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs10.kt
@@ -55,33 +55,363 @@ internal data class DefaultArgs10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>(
 	override fun withArg1(value: A1, representation: String?): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> =
 		this.copy(a1 = value, representation1 = representation)
 
+	override fun <A1New> mapArg1(
+		transform: (A1) -> A1New
+	): Args10<A1New, A2, A3, A4, A5, A6, A7, A8, A9, A10> =
+		Args.of(
+			a1 = transform(a1),
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8,
+			a9 = a9, representation9 = representation9,
+			a10 = a10, representation10 = representation10
+		)
+
+	override fun <A1New> mapArg1WithRepresentation(
+		transform: (A1, String?) -> Pair<A1New, String?>
+	): Args10<A1New, A2, A3, A4, A5, A6, A7, A8, A9, A10> =
+       transform(a1, representation1).let{ (newA1, newRepresentation1) ->
+			Args.of(
+				a1 = newA1, representation1 = newRepresentation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8,
+				a9 = a9, representation9 = representation9,
+				a10 = a10, representation10 = representation10
+			)
+		}
 	override fun withArg2(value: A2, representation: String?): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> =
 		this.copy(a2 = value, representation2 = representation)
 
+	override fun <A2New> mapArg2(
+		transform: (A2) -> A2New
+	): Args10<A1, A2New, A3, A4, A5, A6, A7, A8, A9, A10> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = transform(a2),
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8,
+			a9 = a9, representation9 = representation9,
+			a10 = a10, representation10 = representation10
+		)
+
+	override fun <A2New> mapArg2WithRepresentation(
+		transform: (A2, String?) -> Pair<A2New, String?>
+	): Args10<A1, A2New, A3, A4, A5, A6, A7, A8, A9, A10> =
+       transform(a2, representation2).let{ (newA2, newRepresentation2) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = newA2, representation2 = newRepresentation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8,
+				a9 = a9, representation9 = representation9,
+				a10 = a10, representation10 = representation10
+			)
+		}
 	override fun withArg3(value: A3, representation: String?): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> =
 		this.copy(a3 = value, representation3 = representation)
 
+	override fun <A3New> mapArg3(
+		transform: (A3) -> A3New
+	): Args10<A1, A2, A3New, A4, A5, A6, A7, A8, A9, A10> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = transform(a3),
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8,
+			a9 = a9, representation9 = representation9,
+			a10 = a10, representation10 = representation10
+		)
+
+	override fun <A3New> mapArg3WithRepresentation(
+		transform: (A3, String?) -> Pair<A3New, String?>
+	): Args10<A1, A2, A3New, A4, A5, A6, A7, A8, A9, A10> =
+       transform(a3, representation3).let{ (newA3, newRepresentation3) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = newA3, representation3 = newRepresentation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8,
+				a9 = a9, representation9 = representation9,
+				a10 = a10, representation10 = representation10
+			)
+		}
 	override fun withArg4(value: A4, representation: String?): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> =
 		this.copy(a4 = value, representation4 = representation)
 
+	override fun <A4New> mapArg4(
+		transform: (A4) -> A4New
+	): Args10<A1, A2, A3, A4New, A5, A6, A7, A8, A9, A10> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = transform(a4),
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8,
+			a9 = a9, representation9 = representation9,
+			a10 = a10, representation10 = representation10
+		)
+
+	override fun <A4New> mapArg4WithRepresentation(
+		transform: (A4, String?) -> Pair<A4New, String?>
+	): Args10<A1, A2, A3, A4New, A5, A6, A7, A8, A9, A10> =
+       transform(a4, representation4).let{ (newA4, newRepresentation4) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = newA4, representation4 = newRepresentation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8,
+				a9 = a9, representation9 = representation9,
+				a10 = a10, representation10 = representation10
+			)
+		}
 	override fun withArg5(value: A5, representation: String?): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> =
 		this.copy(a5 = value, representation5 = representation)
 
+	override fun <A5New> mapArg5(
+		transform: (A5) -> A5New
+	): Args10<A1, A2, A3, A4, A5New, A6, A7, A8, A9, A10> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = transform(a5),
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8,
+			a9 = a9, representation9 = representation9,
+			a10 = a10, representation10 = representation10
+		)
+
+	override fun <A5New> mapArg5WithRepresentation(
+		transform: (A5, String?) -> Pair<A5New, String?>
+	): Args10<A1, A2, A3, A4, A5New, A6, A7, A8, A9, A10> =
+       transform(a5, representation5).let{ (newA5, newRepresentation5) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = newA5, representation5 = newRepresentation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8,
+				a9 = a9, representation9 = representation9,
+				a10 = a10, representation10 = representation10
+			)
+		}
 	override fun withArg6(value: A6, representation: String?): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> =
 		this.copy(a6 = value, representation6 = representation)
 
+	override fun <A6New> mapArg6(
+		transform: (A6) -> A6New
+	): Args10<A1, A2, A3, A4, A5, A6New, A7, A8, A9, A10> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = transform(a6),
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8,
+			a9 = a9, representation9 = representation9,
+			a10 = a10, representation10 = representation10
+		)
+
+	override fun <A6New> mapArg6WithRepresentation(
+		transform: (A6, String?) -> Pair<A6New, String?>
+	): Args10<A1, A2, A3, A4, A5, A6New, A7, A8, A9, A10> =
+       transform(a6, representation6).let{ (newA6, newRepresentation6) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = newA6, representation6 = newRepresentation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8,
+				a9 = a9, representation9 = representation9,
+				a10 = a10, representation10 = representation10
+			)
+		}
 	override fun withArg7(value: A7, representation: String?): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> =
 		this.copy(a7 = value, representation7 = representation)
 
+	override fun <A7New> mapArg7(
+		transform: (A7) -> A7New
+	): Args10<A1, A2, A3, A4, A5, A6, A7New, A8, A9, A10> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = transform(a7),
+			a8 = a8, representation8 = representation8,
+			a9 = a9, representation9 = representation9,
+			a10 = a10, representation10 = representation10
+		)
+
+	override fun <A7New> mapArg7WithRepresentation(
+		transform: (A7, String?) -> Pair<A7New, String?>
+	): Args10<A1, A2, A3, A4, A5, A6, A7New, A8, A9, A10> =
+       transform(a7, representation7).let{ (newA7, newRepresentation7) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = newA7, representation7 = newRepresentation7,
+				a8 = a8, representation8 = representation8,
+				a9 = a9, representation9 = representation9,
+				a10 = a10, representation10 = representation10
+			)
+		}
 	override fun withArg8(value: A8, representation: String?): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> =
 		this.copy(a8 = value, representation8 = representation)
 
+	override fun <A8New> mapArg8(
+		transform: (A8) -> A8New
+	): Args10<A1, A2, A3, A4, A5, A6, A7, A8New, A9, A10> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = transform(a8),
+			a9 = a9, representation9 = representation9,
+			a10 = a10, representation10 = representation10
+		)
+
+	override fun <A8New> mapArg8WithRepresentation(
+		transform: (A8, String?) -> Pair<A8New, String?>
+	): Args10<A1, A2, A3, A4, A5, A6, A7, A8New, A9, A10> =
+       transform(a8, representation8).let{ (newA8, newRepresentation8) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = newA8, representation8 = newRepresentation8,
+				a9 = a9, representation9 = representation9,
+				a10 = a10, representation10 = representation10
+			)
+		}
 	override fun withArg9(value: A9, representation: String?): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> =
 		this.copy(a9 = value, representation9 = representation)
 
+	override fun <A9New> mapArg9(
+		transform: (A9) -> A9New
+	): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9New, A10> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8,
+			a9 = transform(a9),
+			a10 = a10, representation10 = representation10
+		)
+
+	override fun <A9New> mapArg9WithRepresentation(
+		transform: (A9, String?) -> Pair<A9New, String?>
+	): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9New, A10> =
+       transform(a9, representation9).let{ (newA9, newRepresentation9) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8,
+				a9 = newA9, representation9 = newRepresentation9,
+				a10 = a10, representation10 = representation10
+			)
+		}
 	override fun withArg10(value: A10, representation: String?): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> =
 		this.copy(a10 = value, representation10 = representation)
 
+	override fun <A10New> mapArg10(
+		transform: (A10) -> A10New
+	): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10New> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8,
+			a9 = a9, representation9 = representation9,
+			a10 = transform(a10)
+		)
+
+	override fun <A10New> mapArg10WithRepresentation(
+		transform: (A10, String?) -> Pair<A10New, String?>
+	): Args10<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10New> =
+       transform(a10, representation10).let{ (newA10, newRepresentation10) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8,
+				a9 = a9, representation9 = representation9,
+				a10 = newA10, representation10 = newRepresentation10
+			)
+		}
 
 	override fun dropArg1(): Args9<A2, A3, A4, A5, A6, A7, A8, A9, A10> =
 		Args.of(

--- a/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs2.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs2.kt
@@ -31,9 +31,43 @@ internal data class DefaultArgs2<A1, A2>(
 	override fun withArg1(value: A1, representation: String?): Args2<A1, A2> =
 		this.copy(a1 = value, representation1 = representation)
 
+	override fun <A1New> mapArg1(
+		transform: (A1) -> A1New
+	): Args2<A1New, A2> =
+		Args.of(
+			a1 = transform(a1),
+			a2 = a2, representation2 = representation2
+		)
+
+	override fun <A1New> mapArg1WithRepresentation(
+		transform: (A1, String?) -> Pair<A1New, String?>
+	): Args2<A1New, A2> =
+       transform(a1, representation1).let{ (newA1, newRepresentation1) ->
+			Args.of(
+				a1 = newA1, representation1 = newRepresentation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2
+			)
+		}
 	override fun withArg2(value: A2, representation: String?): Args2<A1, A2> =
 		this.copy(a2 = value, representation2 = representation)
 
+	override fun <A2New> mapArg2(
+		transform: (A2) -> A2New
+	): Args2<A1, A2New> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = transform(a2)
+		)
+
+	override fun <A2New> mapArg2WithRepresentation(
+		transform: (A2, String?) -> Pair<A2New, String?>
+	): Args2<A1, A2New> =
+       transform(a2, representation2).let{ (newA2, newRepresentation2) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = newA2, representation2 = newRepresentation2
+			)
+		}
 
 	override fun <A3> append(
 		args: Args1<A3>

--- a/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs3.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs3.kt
@@ -34,12 +34,69 @@ internal data class DefaultArgs3<A1, A2, A3>(
 	override fun withArg1(value: A1, representation: String?): Args3<A1, A2, A3> =
 		this.copy(a1 = value, representation1 = representation)
 
+	override fun <A1New> mapArg1(
+		transform: (A1) -> A1New
+	): Args3<A1New, A2, A3> =
+		Args.of(
+			a1 = transform(a1),
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3
+		)
+
+	override fun <A1New> mapArg1WithRepresentation(
+		transform: (A1, String?) -> Pair<A1New, String?>
+	): Args3<A1New, A2, A3> =
+       transform(a1, representation1).let{ (newA1, newRepresentation1) ->
+			Args.of(
+				a1 = newA1, representation1 = newRepresentation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3
+			)
+		}
 	override fun withArg2(value: A2, representation: String?): Args3<A1, A2, A3> =
 		this.copy(a2 = value, representation2 = representation)
 
+	override fun <A2New> mapArg2(
+		transform: (A2) -> A2New
+	): Args3<A1, A2New, A3> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = transform(a2),
+			a3 = a3, representation3 = representation3
+		)
+
+	override fun <A2New> mapArg2WithRepresentation(
+		transform: (A2, String?) -> Pair<A2New, String?>
+	): Args3<A1, A2New, A3> =
+       transform(a2, representation2).let{ (newA2, newRepresentation2) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = newA2, representation2 = newRepresentation2,
+				a3 = a3, representation3 = representation3
+			)
+		}
 	override fun withArg3(value: A3, representation: String?): Args3<A1, A2, A3> =
 		this.copy(a3 = value, representation3 = representation)
 
+	override fun <A3New> mapArg3(
+		transform: (A3) -> A3New
+	): Args3<A1, A2, A3New> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = transform(a3)
+		)
+
+	override fun <A3New> mapArg3WithRepresentation(
+		transform: (A3, String?) -> Pair<A3New, String?>
+	): Args3<A1, A2, A3New> =
+       transform(a3, representation3).let{ (newA3, newRepresentation3) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = newA3, representation3 = newRepresentation3
+			)
+		}
 
 	override fun <A4> append(
 		args: Args1<A4>

--- a/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs4.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs4.kt
@@ -37,15 +37,99 @@ internal data class DefaultArgs4<A1, A2, A3, A4>(
 	override fun withArg1(value: A1, representation: String?): Args4<A1, A2, A3, A4> =
 		this.copy(a1 = value, representation1 = representation)
 
+	override fun <A1New> mapArg1(
+		transform: (A1) -> A1New
+	): Args4<A1New, A2, A3, A4> =
+		Args.of(
+			a1 = transform(a1),
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4
+		)
+
+	override fun <A1New> mapArg1WithRepresentation(
+		transform: (A1, String?) -> Pair<A1New, String?>
+	): Args4<A1New, A2, A3, A4> =
+       transform(a1, representation1).let{ (newA1, newRepresentation1) ->
+			Args.of(
+				a1 = newA1, representation1 = newRepresentation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4
+			)
+		}
 	override fun withArg2(value: A2, representation: String?): Args4<A1, A2, A3, A4> =
 		this.copy(a2 = value, representation2 = representation)
 
+	override fun <A2New> mapArg2(
+		transform: (A2) -> A2New
+	): Args4<A1, A2New, A3, A4> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = transform(a2),
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4
+		)
+
+	override fun <A2New> mapArg2WithRepresentation(
+		transform: (A2, String?) -> Pair<A2New, String?>
+	): Args4<A1, A2New, A3, A4> =
+       transform(a2, representation2).let{ (newA2, newRepresentation2) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = newA2, representation2 = newRepresentation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4
+			)
+		}
 	override fun withArg3(value: A3, representation: String?): Args4<A1, A2, A3, A4> =
 		this.copy(a3 = value, representation3 = representation)
 
+	override fun <A3New> mapArg3(
+		transform: (A3) -> A3New
+	): Args4<A1, A2, A3New, A4> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = transform(a3),
+			a4 = a4, representation4 = representation4
+		)
+
+	override fun <A3New> mapArg3WithRepresentation(
+		transform: (A3, String?) -> Pair<A3New, String?>
+	): Args4<A1, A2, A3New, A4> =
+       transform(a3, representation3).let{ (newA3, newRepresentation3) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = newA3, representation3 = newRepresentation3,
+				a4 = a4, representation4 = representation4
+			)
+		}
 	override fun withArg4(value: A4, representation: String?): Args4<A1, A2, A3, A4> =
 		this.copy(a4 = value, representation4 = representation)
 
+	override fun <A4New> mapArg4(
+		transform: (A4) -> A4New
+	): Args4<A1, A2, A3, A4New> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = transform(a4)
+		)
+
+	override fun <A4New> mapArg4WithRepresentation(
+		transform: (A4, String?) -> Pair<A4New, String?>
+	): Args4<A1, A2, A3, A4New> =
+       transform(a4, representation4).let{ (newA4, newRepresentation4) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = newA4, representation4 = newRepresentation4
+			)
+		}
 
 	override fun <A5> append(
 		args: Args1<A5>

--- a/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs5.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs5.kt
@@ -40,18 +40,133 @@ internal data class DefaultArgs5<A1, A2, A3, A4, A5>(
 	override fun withArg1(value: A1, representation: String?): Args5<A1, A2, A3, A4, A5> =
 		this.copy(a1 = value, representation1 = representation)
 
+	override fun <A1New> mapArg1(
+		transform: (A1) -> A1New
+	): Args5<A1New, A2, A3, A4, A5> =
+		Args.of(
+			a1 = transform(a1),
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5
+		)
+
+	override fun <A1New> mapArg1WithRepresentation(
+		transform: (A1, String?) -> Pair<A1New, String?>
+	): Args5<A1New, A2, A3, A4, A5> =
+       transform(a1, representation1).let{ (newA1, newRepresentation1) ->
+			Args.of(
+				a1 = newA1, representation1 = newRepresentation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5
+			)
+		}
 	override fun withArg2(value: A2, representation: String?): Args5<A1, A2, A3, A4, A5> =
 		this.copy(a2 = value, representation2 = representation)
 
+	override fun <A2New> mapArg2(
+		transform: (A2) -> A2New
+	): Args5<A1, A2New, A3, A4, A5> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = transform(a2),
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5
+		)
+
+	override fun <A2New> mapArg2WithRepresentation(
+		transform: (A2, String?) -> Pair<A2New, String?>
+	): Args5<A1, A2New, A3, A4, A5> =
+       transform(a2, representation2).let{ (newA2, newRepresentation2) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = newA2, representation2 = newRepresentation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5
+			)
+		}
 	override fun withArg3(value: A3, representation: String?): Args5<A1, A2, A3, A4, A5> =
 		this.copy(a3 = value, representation3 = representation)
 
+	override fun <A3New> mapArg3(
+		transform: (A3) -> A3New
+	): Args5<A1, A2, A3New, A4, A5> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = transform(a3),
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5
+		)
+
+	override fun <A3New> mapArg3WithRepresentation(
+		transform: (A3, String?) -> Pair<A3New, String?>
+	): Args5<A1, A2, A3New, A4, A5> =
+       transform(a3, representation3).let{ (newA3, newRepresentation3) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = newA3, representation3 = newRepresentation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5
+			)
+		}
 	override fun withArg4(value: A4, representation: String?): Args5<A1, A2, A3, A4, A5> =
 		this.copy(a4 = value, representation4 = representation)
 
+	override fun <A4New> mapArg4(
+		transform: (A4) -> A4New
+	): Args5<A1, A2, A3, A4New, A5> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = transform(a4),
+			a5 = a5, representation5 = representation5
+		)
+
+	override fun <A4New> mapArg4WithRepresentation(
+		transform: (A4, String?) -> Pair<A4New, String?>
+	): Args5<A1, A2, A3, A4New, A5> =
+       transform(a4, representation4).let{ (newA4, newRepresentation4) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = newA4, representation4 = newRepresentation4,
+				a5 = a5, representation5 = representation5
+			)
+		}
 	override fun withArg5(value: A5, representation: String?): Args5<A1, A2, A3, A4, A5> =
 		this.copy(a5 = value, representation5 = representation)
 
+	override fun <A5New> mapArg5(
+		transform: (A5) -> A5New
+	): Args5<A1, A2, A3, A4, A5New> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = transform(a5)
+		)
+
+	override fun <A5New> mapArg5WithRepresentation(
+		transform: (A5, String?) -> Pair<A5New, String?>
+	): Args5<A1, A2, A3, A4, A5New> =
+       transform(a5, representation5).let{ (newA5, newRepresentation5) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = newA5, representation5 = newRepresentation5
+			)
+		}
 
 	override fun <A6> append(
 		args: Args1<A6>

--- a/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs6.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs6.kt
@@ -43,21 +43,171 @@ internal data class DefaultArgs6<A1, A2, A3, A4, A5, A6>(
 	override fun withArg1(value: A1, representation: String?): Args6<A1, A2, A3, A4, A5, A6> =
 		this.copy(a1 = value, representation1 = representation)
 
+	override fun <A1New> mapArg1(
+		transform: (A1) -> A1New
+	): Args6<A1New, A2, A3, A4, A5, A6> =
+		Args.of(
+			a1 = transform(a1),
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6
+		)
+
+	override fun <A1New> mapArg1WithRepresentation(
+		transform: (A1, String?) -> Pair<A1New, String?>
+	): Args6<A1New, A2, A3, A4, A5, A6> =
+       transform(a1, representation1).let{ (newA1, newRepresentation1) ->
+			Args.of(
+				a1 = newA1, representation1 = newRepresentation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6
+			)
+		}
 	override fun withArg2(value: A2, representation: String?): Args6<A1, A2, A3, A4, A5, A6> =
 		this.copy(a2 = value, representation2 = representation)
 
+	override fun <A2New> mapArg2(
+		transform: (A2) -> A2New
+	): Args6<A1, A2New, A3, A4, A5, A6> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = transform(a2),
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6
+		)
+
+	override fun <A2New> mapArg2WithRepresentation(
+		transform: (A2, String?) -> Pair<A2New, String?>
+	): Args6<A1, A2New, A3, A4, A5, A6> =
+       transform(a2, representation2).let{ (newA2, newRepresentation2) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = newA2, representation2 = newRepresentation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6
+			)
+		}
 	override fun withArg3(value: A3, representation: String?): Args6<A1, A2, A3, A4, A5, A6> =
 		this.copy(a3 = value, representation3 = representation)
 
+	override fun <A3New> mapArg3(
+		transform: (A3) -> A3New
+	): Args6<A1, A2, A3New, A4, A5, A6> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = transform(a3),
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6
+		)
+
+	override fun <A3New> mapArg3WithRepresentation(
+		transform: (A3, String?) -> Pair<A3New, String?>
+	): Args6<A1, A2, A3New, A4, A5, A6> =
+       transform(a3, representation3).let{ (newA3, newRepresentation3) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = newA3, representation3 = newRepresentation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6
+			)
+		}
 	override fun withArg4(value: A4, representation: String?): Args6<A1, A2, A3, A4, A5, A6> =
 		this.copy(a4 = value, representation4 = representation)
 
+	override fun <A4New> mapArg4(
+		transform: (A4) -> A4New
+	): Args6<A1, A2, A3, A4New, A5, A6> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = transform(a4),
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6
+		)
+
+	override fun <A4New> mapArg4WithRepresentation(
+		transform: (A4, String?) -> Pair<A4New, String?>
+	): Args6<A1, A2, A3, A4New, A5, A6> =
+       transform(a4, representation4).let{ (newA4, newRepresentation4) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = newA4, representation4 = newRepresentation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6
+			)
+		}
 	override fun withArg5(value: A5, representation: String?): Args6<A1, A2, A3, A4, A5, A6> =
 		this.copy(a5 = value, representation5 = representation)
 
+	override fun <A5New> mapArg5(
+		transform: (A5) -> A5New
+	): Args6<A1, A2, A3, A4, A5New, A6> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = transform(a5),
+			a6 = a6, representation6 = representation6
+		)
+
+	override fun <A5New> mapArg5WithRepresentation(
+		transform: (A5, String?) -> Pair<A5New, String?>
+	): Args6<A1, A2, A3, A4, A5New, A6> =
+       transform(a5, representation5).let{ (newA5, newRepresentation5) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = newA5, representation5 = newRepresentation5,
+				a6 = a6, representation6 = representation6
+			)
+		}
 	override fun withArg6(value: A6, representation: String?): Args6<A1, A2, A3, A4, A5, A6> =
 		this.copy(a6 = value, representation6 = representation)
 
+	override fun <A6New> mapArg6(
+		transform: (A6) -> A6New
+	): Args6<A1, A2, A3, A4, A5, A6New> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = transform(a6)
+		)
+
+	override fun <A6New> mapArg6WithRepresentation(
+		transform: (A6, String?) -> Pair<A6New, String?>
+	): Args6<A1, A2, A3, A4, A5, A6New> =
+       transform(a6, representation6).let{ (newA6, newRepresentation6) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = newA6, representation6 = newRepresentation6
+			)
+		}
 
 	override fun <A7> append(
 		args: Args1<A7>

--- a/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs7.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs7.kt
@@ -46,24 +46,213 @@ internal data class DefaultArgs7<A1, A2, A3, A4, A5, A6, A7>(
 	override fun withArg1(value: A1, representation: String?): Args7<A1, A2, A3, A4, A5, A6, A7> =
 		this.copy(a1 = value, representation1 = representation)
 
+	override fun <A1New> mapArg1(
+		transform: (A1) -> A1New
+	): Args7<A1New, A2, A3, A4, A5, A6, A7> =
+		Args.of(
+			a1 = transform(a1),
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7
+		)
+
+	override fun <A1New> mapArg1WithRepresentation(
+		transform: (A1, String?) -> Pair<A1New, String?>
+	): Args7<A1New, A2, A3, A4, A5, A6, A7> =
+       transform(a1, representation1).let{ (newA1, newRepresentation1) ->
+			Args.of(
+				a1 = newA1, representation1 = newRepresentation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7
+			)
+		}
 	override fun withArg2(value: A2, representation: String?): Args7<A1, A2, A3, A4, A5, A6, A7> =
 		this.copy(a2 = value, representation2 = representation)
 
+	override fun <A2New> mapArg2(
+		transform: (A2) -> A2New
+	): Args7<A1, A2New, A3, A4, A5, A6, A7> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = transform(a2),
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7
+		)
+
+	override fun <A2New> mapArg2WithRepresentation(
+		transform: (A2, String?) -> Pair<A2New, String?>
+	): Args7<A1, A2New, A3, A4, A5, A6, A7> =
+       transform(a2, representation2).let{ (newA2, newRepresentation2) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = newA2, representation2 = newRepresentation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7
+			)
+		}
 	override fun withArg3(value: A3, representation: String?): Args7<A1, A2, A3, A4, A5, A6, A7> =
 		this.copy(a3 = value, representation3 = representation)
 
+	override fun <A3New> mapArg3(
+		transform: (A3) -> A3New
+	): Args7<A1, A2, A3New, A4, A5, A6, A7> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = transform(a3),
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7
+		)
+
+	override fun <A3New> mapArg3WithRepresentation(
+		transform: (A3, String?) -> Pair<A3New, String?>
+	): Args7<A1, A2, A3New, A4, A5, A6, A7> =
+       transform(a3, representation3).let{ (newA3, newRepresentation3) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = newA3, representation3 = newRepresentation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7
+			)
+		}
 	override fun withArg4(value: A4, representation: String?): Args7<A1, A2, A3, A4, A5, A6, A7> =
 		this.copy(a4 = value, representation4 = representation)
 
+	override fun <A4New> mapArg4(
+		transform: (A4) -> A4New
+	): Args7<A1, A2, A3, A4New, A5, A6, A7> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = transform(a4),
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7
+		)
+
+	override fun <A4New> mapArg4WithRepresentation(
+		transform: (A4, String?) -> Pair<A4New, String?>
+	): Args7<A1, A2, A3, A4New, A5, A6, A7> =
+       transform(a4, representation4).let{ (newA4, newRepresentation4) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = newA4, representation4 = newRepresentation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7
+			)
+		}
 	override fun withArg5(value: A5, representation: String?): Args7<A1, A2, A3, A4, A5, A6, A7> =
 		this.copy(a5 = value, representation5 = representation)
 
+	override fun <A5New> mapArg5(
+		transform: (A5) -> A5New
+	): Args7<A1, A2, A3, A4, A5New, A6, A7> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = transform(a5),
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7
+		)
+
+	override fun <A5New> mapArg5WithRepresentation(
+		transform: (A5, String?) -> Pair<A5New, String?>
+	): Args7<A1, A2, A3, A4, A5New, A6, A7> =
+       transform(a5, representation5).let{ (newA5, newRepresentation5) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = newA5, representation5 = newRepresentation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7
+			)
+		}
 	override fun withArg6(value: A6, representation: String?): Args7<A1, A2, A3, A4, A5, A6, A7> =
 		this.copy(a6 = value, representation6 = representation)
 
+	override fun <A6New> mapArg6(
+		transform: (A6) -> A6New
+	): Args7<A1, A2, A3, A4, A5, A6New, A7> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = transform(a6),
+			a7 = a7, representation7 = representation7
+		)
+
+	override fun <A6New> mapArg6WithRepresentation(
+		transform: (A6, String?) -> Pair<A6New, String?>
+	): Args7<A1, A2, A3, A4, A5, A6New, A7> =
+       transform(a6, representation6).let{ (newA6, newRepresentation6) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = newA6, representation6 = newRepresentation6,
+				a7 = a7, representation7 = representation7
+			)
+		}
 	override fun withArg7(value: A7, representation: String?): Args7<A1, A2, A3, A4, A5, A6, A7> =
 		this.copy(a7 = value, representation7 = representation)
 
+	override fun <A7New> mapArg7(
+		transform: (A7) -> A7New
+	): Args7<A1, A2, A3, A4, A5, A6, A7New> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = transform(a7)
+		)
+
+	override fun <A7New> mapArg7WithRepresentation(
+		transform: (A7, String?) -> Pair<A7New, String?>
+	): Args7<A1, A2, A3, A4, A5, A6, A7New> =
+       transform(a7, representation7).let{ (newA7, newRepresentation7) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = newA7, representation7 = newRepresentation7
+			)
+		}
 
 	override fun <A8> append(
 		args: Args1<A8>

--- a/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs8.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs8.kt
@@ -49,27 +49,259 @@ internal data class DefaultArgs8<A1, A2, A3, A4, A5, A6, A7, A8>(
 	override fun withArg1(value: A1, representation: String?): Args8<A1, A2, A3, A4, A5, A6, A7, A8> =
 		this.copy(a1 = value, representation1 = representation)
 
+	override fun <A1New> mapArg1(
+		transform: (A1) -> A1New
+	): Args8<A1New, A2, A3, A4, A5, A6, A7, A8> =
+		Args.of(
+			a1 = transform(a1),
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8
+		)
+
+	override fun <A1New> mapArg1WithRepresentation(
+		transform: (A1, String?) -> Pair<A1New, String?>
+	): Args8<A1New, A2, A3, A4, A5, A6, A7, A8> =
+       transform(a1, representation1).let{ (newA1, newRepresentation1) ->
+			Args.of(
+				a1 = newA1, representation1 = newRepresentation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8
+			)
+		}
 	override fun withArg2(value: A2, representation: String?): Args8<A1, A2, A3, A4, A5, A6, A7, A8> =
 		this.copy(a2 = value, representation2 = representation)
 
+	override fun <A2New> mapArg2(
+		transform: (A2) -> A2New
+	): Args8<A1, A2New, A3, A4, A5, A6, A7, A8> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = transform(a2),
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8
+		)
+
+	override fun <A2New> mapArg2WithRepresentation(
+		transform: (A2, String?) -> Pair<A2New, String?>
+	): Args8<A1, A2New, A3, A4, A5, A6, A7, A8> =
+       transform(a2, representation2).let{ (newA2, newRepresentation2) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = newA2, representation2 = newRepresentation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8
+			)
+		}
 	override fun withArg3(value: A3, representation: String?): Args8<A1, A2, A3, A4, A5, A6, A7, A8> =
 		this.copy(a3 = value, representation3 = representation)
 
+	override fun <A3New> mapArg3(
+		transform: (A3) -> A3New
+	): Args8<A1, A2, A3New, A4, A5, A6, A7, A8> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = transform(a3),
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8
+		)
+
+	override fun <A3New> mapArg3WithRepresentation(
+		transform: (A3, String?) -> Pair<A3New, String?>
+	): Args8<A1, A2, A3New, A4, A5, A6, A7, A8> =
+       transform(a3, representation3).let{ (newA3, newRepresentation3) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = newA3, representation3 = newRepresentation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8
+			)
+		}
 	override fun withArg4(value: A4, representation: String?): Args8<A1, A2, A3, A4, A5, A6, A7, A8> =
 		this.copy(a4 = value, representation4 = representation)
 
+	override fun <A4New> mapArg4(
+		transform: (A4) -> A4New
+	): Args8<A1, A2, A3, A4New, A5, A6, A7, A8> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = transform(a4),
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8
+		)
+
+	override fun <A4New> mapArg4WithRepresentation(
+		transform: (A4, String?) -> Pair<A4New, String?>
+	): Args8<A1, A2, A3, A4New, A5, A6, A7, A8> =
+       transform(a4, representation4).let{ (newA4, newRepresentation4) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = newA4, representation4 = newRepresentation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8
+			)
+		}
 	override fun withArg5(value: A5, representation: String?): Args8<A1, A2, A3, A4, A5, A6, A7, A8> =
 		this.copy(a5 = value, representation5 = representation)
 
+	override fun <A5New> mapArg5(
+		transform: (A5) -> A5New
+	): Args8<A1, A2, A3, A4, A5New, A6, A7, A8> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = transform(a5),
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8
+		)
+
+	override fun <A5New> mapArg5WithRepresentation(
+		transform: (A5, String?) -> Pair<A5New, String?>
+	): Args8<A1, A2, A3, A4, A5New, A6, A7, A8> =
+       transform(a5, representation5).let{ (newA5, newRepresentation5) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = newA5, representation5 = newRepresentation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8
+			)
+		}
 	override fun withArg6(value: A6, representation: String?): Args8<A1, A2, A3, A4, A5, A6, A7, A8> =
 		this.copy(a6 = value, representation6 = representation)
 
+	override fun <A6New> mapArg6(
+		transform: (A6) -> A6New
+	): Args8<A1, A2, A3, A4, A5, A6New, A7, A8> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = transform(a6),
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8
+		)
+
+	override fun <A6New> mapArg6WithRepresentation(
+		transform: (A6, String?) -> Pair<A6New, String?>
+	): Args8<A1, A2, A3, A4, A5, A6New, A7, A8> =
+       transform(a6, representation6).let{ (newA6, newRepresentation6) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = newA6, representation6 = newRepresentation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8
+			)
+		}
 	override fun withArg7(value: A7, representation: String?): Args8<A1, A2, A3, A4, A5, A6, A7, A8> =
 		this.copy(a7 = value, representation7 = representation)
 
+	override fun <A7New> mapArg7(
+		transform: (A7) -> A7New
+	): Args8<A1, A2, A3, A4, A5, A6, A7New, A8> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = transform(a7),
+			a8 = a8, representation8 = representation8
+		)
+
+	override fun <A7New> mapArg7WithRepresentation(
+		transform: (A7, String?) -> Pair<A7New, String?>
+	): Args8<A1, A2, A3, A4, A5, A6, A7New, A8> =
+       transform(a7, representation7).let{ (newA7, newRepresentation7) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = newA7, representation7 = newRepresentation7,
+				a8 = a8, representation8 = representation8
+			)
+		}
 	override fun withArg8(value: A8, representation: String?): Args8<A1, A2, A3, A4, A5, A6, A7, A8> =
 		this.copy(a8 = value, representation8 = representation)
 
+	override fun <A8New> mapArg8(
+		transform: (A8) -> A8New
+	): Args8<A1, A2, A3, A4, A5, A6, A7, A8New> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = transform(a8)
+		)
+
+	override fun <A8New> mapArg8WithRepresentation(
+		transform: (A8, String?) -> Pair<A8New, String?>
+	): Args8<A1, A2, A3, A4, A5, A6, A7, A8New> =
+       transform(a8, representation8).let{ (newA8, newRepresentation8) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = newA8, representation8 = newRepresentation8
+			)
+		}
 
 	override fun <A9> append(
 		args: Args1<A9>

--- a/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs9.kt
+++ b/src/main/generated/kotlin/com/tegonal/minimalist/impl/DefaultArgs9.kt
@@ -52,30 +52,309 @@ internal data class DefaultArgs9<A1, A2, A3, A4, A5, A6, A7, A8, A9>(
 	override fun withArg1(value: A1, representation: String?): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9> =
 		this.copy(a1 = value, representation1 = representation)
 
+	override fun <A1New> mapArg1(
+		transform: (A1) -> A1New
+	): Args9<A1New, A2, A3, A4, A5, A6, A7, A8, A9> =
+		Args.of(
+			a1 = transform(a1),
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8,
+			a9 = a9, representation9 = representation9
+		)
+
+	override fun <A1New> mapArg1WithRepresentation(
+		transform: (A1, String?) -> Pair<A1New, String?>
+	): Args9<A1New, A2, A3, A4, A5, A6, A7, A8, A9> =
+       transform(a1, representation1).let{ (newA1, newRepresentation1) ->
+			Args.of(
+				a1 = newA1, representation1 = newRepresentation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8,
+				a9 = a9, representation9 = representation9
+			)
+		}
 	override fun withArg2(value: A2, representation: String?): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9> =
 		this.copy(a2 = value, representation2 = representation)
 
+	override fun <A2New> mapArg2(
+		transform: (A2) -> A2New
+	): Args9<A1, A2New, A3, A4, A5, A6, A7, A8, A9> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = transform(a2),
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8,
+			a9 = a9, representation9 = representation9
+		)
+
+	override fun <A2New> mapArg2WithRepresentation(
+		transform: (A2, String?) -> Pair<A2New, String?>
+	): Args9<A1, A2New, A3, A4, A5, A6, A7, A8, A9> =
+       transform(a2, representation2).let{ (newA2, newRepresentation2) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = newA2, representation2 = newRepresentation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8,
+				a9 = a9, representation9 = representation9
+			)
+		}
 	override fun withArg3(value: A3, representation: String?): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9> =
 		this.copy(a3 = value, representation3 = representation)
 
+	override fun <A3New> mapArg3(
+		transform: (A3) -> A3New
+	): Args9<A1, A2, A3New, A4, A5, A6, A7, A8, A9> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = transform(a3),
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8,
+			a9 = a9, representation9 = representation9
+		)
+
+	override fun <A3New> mapArg3WithRepresentation(
+		transform: (A3, String?) -> Pair<A3New, String?>
+	): Args9<A1, A2, A3New, A4, A5, A6, A7, A8, A9> =
+       transform(a3, representation3).let{ (newA3, newRepresentation3) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = newA3, representation3 = newRepresentation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8,
+				a9 = a9, representation9 = representation9
+			)
+		}
 	override fun withArg4(value: A4, representation: String?): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9> =
 		this.copy(a4 = value, representation4 = representation)
 
+	override fun <A4New> mapArg4(
+		transform: (A4) -> A4New
+	): Args9<A1, A2, A3, A4New, A5, A6, A7, A8, A9> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = transform(a4),
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8,
+			a9 = a9, representation9 = representation9
+		)
+
+	override fun <A4New> mapArg4WithRepresentation(
+		transform: (A4, String?) -> Pair<A4New, String?>
+	): Args9<A1, A2, A3, A4New, A5, A6, A7, A8, A9> =
+       transform(a4, representation4).let{ (newA4, newRepresentation4) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = newA4, representation4 = newRepresentation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8,
+				a9 = a9, representation9 = representation9
+			)
+		}
 	override fun withArg5(value: A5, representation: String?): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9> =
 		this.copy(a5 = value, representation5 = representation)
 
+	override fun <A5New> mapArg5(
+		transform: (A5) -> A5New
+	): Args9<A1, A2, A3, A4, A5New, A6, A7, A8, A9> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = transform(a5),
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8,
+			a9 = a9, representation9 = representation9
+		)
+
+	override fun <A5New> mapArg5WithRepresentation(
+		transform: (A5, String?) -> Pair<A5New, String?>
+	): Args9<A1, A2, A3, A4, A5New, A6, A7, A8, A9> =
+       transform(a5, representation5).let{ (newA5, newRepresentation5) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = newA5, representation5 = newRepresentation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8,
+				a9 = a9, representation9 = representation9
+			)
+		}
 	override fun withArg6(value: A6, representation: String?): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9> =
 		this.copy(a6 = value, representation6 = representation)
 
+	override fun <A6New> mapArg6(
+		transform: (A6) -> A6New
+	): Args9<A1, A2, A3, A4, A5, A6New, A7, A8, A9> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = transform(a6),
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8,
+			a9 = a9, representation9 = representation9
+		)
+
+	override fun <A6New> mapArg6WithRepresentation(
+		transform: (A6, String?) -> Pair<A6New, String?>
+	): Args9<A1, A2, A3, A4, A5, A6New, A7, A8, A9> =
+       transform(a6, representation6).let{ (newA6, newRepresentation6) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = newA6, representation6 = newRepresentation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8,
+				a9 = a9, representation9 = representation9
+			)
+		}
 	override fun withArg7(value: A7, representation: String?): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9> =
 		this.copy(a7 = value, representation7 = representation)
 
+	override fun <A7New> mapArg7(
+		transform: (A7) -> A7New
+	): Args9<A1, A2, A3, A4, A5, A6, A7New, A8, A9> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = transform(a7),
+			a8 = a8, representation8 = representation8,
+			a9 = a9, representation9 = representation9
+		)
+
+	override fun <A7New> mapArg7WithRepresentation(
+		transform: (A7, String?) -> Pair<A7New, String?>
+	): Args9<A1, A2, A3, A4, A5, A6, A7New, A8, A9> =
+       transform(a7, representation7).let{ (newA7, newRepresentation7) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = newA7, representation7 = newRepresentation7,
+				a8 = a8, representation8 = representation8,
+				a9 = a9, representation9 = representation9
+			)
+		}
 	override fun withArg8(value: A8, representation: String?): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9> =
 		this.copy(a8 = value, representation8 = representation)
 
+	override fun <A8New> mapArg8(
+		transform: (A8) -> A8New
+	): Args9<A1, A2, A3, A4, A5, A6, A7, A8New, A9> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = transform(a8),
+			a9 = a9, representation9 = representation9
+		)
+
+	override fun <A8New> mapArg8WithRepresentation(
+		transform: (A8, String?) -> Pair<A8New, String?>
+	): Args9<A1, A2, A3, A4, A5, A6, A7, A8New, A9> =
+       transform(a8, representation8).let{ (newA8, newRepresentation8) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = newA8, representation8 = newRepresentation8,
+				a9 = a9, representation9 = representation9
+			)
+		}
 	override fun withArg9(value: A9, representation: String?): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9> =
 		this.copy(a9 = value, representation9 = representation)
 
+	override fun <A9New> mapArg9(
+		transform: (A9) -> A9New
+	): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9New> =
+		Args.of(
+			a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+			a2 = a2, representation2 = representation2,
+			a3 = a3, representation3 = representation3,
+			a4 = a4, representation4 = representation4,
+			a5 = a5, representation5 = representation5,
+			a6 = a6, representation6 = representation6,
+			a7 = a7, representation7 = representation7,
+			a8 = a8, representation8 = representation8,
+			a9 = transform(a9)
+		)
+
+	override fun <A9New> mapArg9WithRepresentation(
+		transform: (A9, String?) -> Pair<A9New, String?>
+	): Args9<A1, A2, A3, A4, A5, A6, A7, A8, A9New> =
+       transform(a9, representation9).let{ (newA9, newRepresentation9) ->
+			Args.of(
+				a1 = a1, representation1 = representation1?.let { r -> Representation(r) },
+				a2 = a2, representation2 = representation2,
+				a3 = a3, representation3 = representation3,
+				a4 = a4, representation4 = representation4,
+				a5 = a5, representation5 = representation5,
+				a6 = a6, representation6 = representation6,
+				a7 = a7, representation7 = representation7,
+				a8 = a8, representation8 = representation8,
+				a9 = newA9, representation9 = newRepresentation9
+			)
+		}
 
 	override fun <A10> append(
 		args: Args1<A10>

--- a/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args10MapArgTest.kt
+++ b/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args10MapArgTest.kt
@@ -1,0 +1,1500 @@
+// --------------------------------------------------------------------------------------------------------------------
+// automatically generated, don't modify here but in:
+// gradle/code-generation/src/main/kotlin/code-generation.generate.gradle.kts
+// --------------------------------------------------------------------------------------------------------------------
+package com.tegonal.minimalist.arguments.mapArg
+
+import ch.tutteli.atrium.api.verbs.expect
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import com.tegonal.minimalist.*
+import com.tegonal.minimalist.atrium.*
+import java.math.BigInteger
+import java.time.LocalDate
+
+class Args10MapArgTest {
+
+	@Test
+	fun mapArg1() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg1 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			a10.toEqual(args.a10)
+			representation1.toEqual(null)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg1WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg1WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			a10.toEqual(args.a10)
+			representation1.toEqual("rep 1 modified")
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg2() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg2 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			a10.toEqual(args.a10)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(null)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg2WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg2WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			a10.toEqual(args.a10)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual("rep 2 modified")
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg3() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg3 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(3F)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			a10.toEqual(args.a10)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(null)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg3WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg3WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(3F)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			a10.toEqual(args.a10)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual("rep 3 modified")
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg4() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg4 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(4.0)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			a10.toEqual(args.a10)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(null)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg4WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg4WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(4.0)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			a10.toEqual(args.a10)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual("rep 4 modified")
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg5() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg5 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual('c')
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			a10.toEqual(args.a10)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(null)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg5WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg5WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual('c')
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			a10.toEqual(args.a10)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual("rep 5 modified")
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg6() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg6 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual("string")
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			a10.toEqual(args.a10)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(null)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg6WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg6WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual("string")
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			a10.toEqual(args.a10)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual("rep 6 modified")
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg7() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg7 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(LocalDate.now())
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			a10.toEqual(args.a10)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(null)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg7WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg7WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(LocalDate.now())
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			a10.toEqual(args.a10)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual("rep 7 modified")
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg8() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg8 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(1.toShort())
+			a9.toEqual(args.a9)
+			a10.toEqual(args.a10)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(null)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg8WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg8WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(1.toShort())
+			a9.toEqual(args.a9)
+			a10.toEqual(args.a10)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual("rep 8 modified")
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg9() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg9 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(2.toByte())
+			a10.toEqual(args.a10)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(null)
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg9WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg9WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(2.toByte())
+			a10.toEqual(args.a10)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual("rep 9 modified")
+			representation10.toEqual(args.representation10)
+		}
+	}
+
+	@Test
+	fun mapArg10() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg10 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			a10.toEqual(3.toBigInteger())
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual(null)
+		}
+	}
+
+	@Test
+	fun mapArg10WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			listOf(3.toBigInteger()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9",
+			representation10 = "rep 10"
+		)
+		val argsResult = args.mapArg10WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			a10.toEqual(listOf(3.toBigInteger()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+			representation10.toEqual("rep 10")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			a10.toEqual(3.toBigInteger())
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+			representation10.toEqual("rep 10 modified")
+		}
+	}
+
+}

--- a/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args1MapArgTest.kt
+++ b/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args1MapArgTest.kt
@@ -1,0 +1,60 @@
+// --------------------------------------------------------------------------------------------------------------------
+// automatically generated, don't modify here but in:
+// gradle/code-generation/src/main/kotlin/code-generation.generate.gradle.kts
+// --------------------------------------------------------------------------------------------------------------------
+package com.tegonal.minimalist.arguments.mapArg
+
+import ch.tutteli.atrium.api.verbs.expect
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import com.tegonal.minimalist.*
+import com.tegonal.minimalist.atrium.*
+import java.math.BigInteger
+import java.time.LocalDate
+
+class Args1MapArgTest {
+
+	@Test
+	fun mapArg1() {
+		val args = Args.of(
+			listOf(1),
+			representation1 = Representation("rep 1")
+		)
+		val argsResult = args.mapArg1 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			representation1.toEqual("rep 1")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			representation1.toEqual(null)
+		}
+	}
+
+	@Test
+	fun mapArg1WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			representation1 = Representation("rep 1")
+		)
+		val argsResult = args.mapArg1WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			representation1.toEqual("rep 1")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			representation1.toEqual("rep 1 modified")
+		}
+	}
+
+}

--- a/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args2MapArgTest.kt
+++ b/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args2MapArgTest.kt
@@ -1,0 +1,124 @@
+// --------------------------------------------------------------------------------------------------------------------
+// automatically generated, don't modify here but in:
+// gradle/code-generation/src/main/kotlin/code-generation.generate.gradle.kts
+// --------------------------------------------------------------------------------------------------------------------
+package com.tegonal.minimalist.arguments.mapArg
+
+import ch.tutteli.atrium.api.verbs.expect
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import com.tegonal.minimalist.*
+import com.tegonal.minimalist.atrium.*
+import java.math.BigInteger
+import java.time.LocalDate
+
+class Args2MapArgTest {
+
+	@Test
+	fun mapArg1() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2"
+		)
+		val argsResult = args.mapArg1 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			representation1.toEqual(null)
+			representation2.toEqual(args.representation2)
+		}
+	}
+
+	@Test
+	fun mapArg1WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2"
+		)
+		val argsResult = args.mapArg1WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			representation1.toEqual("rep 1 modified")
+			representation2.toEqual(args.representation2)
+		}
+	}
+
+	@Test
+	fun mapArg2() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2"
+		)
+		val argsResult = args.mapArg2 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(null)
+		}
+	}
+
+	@Test
+	fun mapArg2WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2"
+		)
+		val argsResult = args.mapArg2WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual("rep 2 modified")
+		}
+	}
+
+}

--- a/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args3MapArgTest.kt
+++ b/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args3MapArgTest.kt
@@ -1,0 +1,212 @@
+// --------------------------------------------------------------------------------------------------------------------
+// automatically generated, don't modify here but in:
+// gradle/code-generation/src/main/kotlin/code-generation.generate.gradle.kts
+// --------------------------------------------------------------------------------------------------------------------
+package com.tegonal.minimalist.arguments.mapArg
+
+import ch.tutteli.atrium.api.verbs.expect
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import com.tegonal.minimalist.*
+import com.tegonal.minimalist.atrium.*
+import java.math.BigInteger
+import java.time.LocalDate
+
+class Args3MapArgTest {
+
+	@Test
+	fun mapArg1() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3"
+		)
+		val argsResult = args.mapArg1 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			representation1.toEqual(null)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+		}
+	}
+
+	@Test
+	fun mapArg1WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3"
+		)
+		val argsResult = args.mapArg1WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			representation1.toEqual("rep 1 modified")
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+		}
+	}
+
+	@Test
+	fun mapArg2() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3"
+		)
+		val argsResult = args.mapArg2 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			a3.toEqual(args.a3)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(null)
+			representation3.toEqual(args.representation3)
+		}
+	}
+
+	@Test
+	fun mapArg2WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3"
+		)
+		val argsResult = args.mapArg2WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			a3.toEqual(args.a3)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual("rep 2 modified")
+			representation3.toEqual(args.representation3)
+		}
+	}
+
+	@Test
+	fun mapArg3() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3"
+		)
+		val argsResult = args.mapArg3 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(3F)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(null)
+		}
+	}
+
+	@Test
+	fun mapArg3WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3"
+		)
+		val argsResult = args.mapArg3WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(3F)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual("rep 3 modified")
+		}
+	}
+
+}

--- a/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args4MapArgTest.kt
+++ b/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args4MapArgTest.kt
@@ -1,0 +1,324 @@
+// --------------------------------------------------------------------------------------------------------------------
+// automatically generated, don't modify here but in:
+// gradle/code-generation/src/main/kotlin/code-generation.generate.gradle.kts
+// --------------------------------------------------------------------------------------------------------------------
+package com.tegonal.minimalist.arguments.mapArg
+
+import ch.tutteli.atrium.api.verbs.expect
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import com.tegonal.minimalist.*
+import com.tegonal.minimalist.atrium.*
+import java.math.BigInteger
+import java.time.LocalDate
+
+class Args4MapArgTest {
+
+	@Test
+	fun mapArg1() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4"
+		)
+		val argsResult = args.mapArg1 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			representation1.toEqual(null)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+		}
+	}
+
+	@Test
+	fun mapArg1WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4"
+		)
+		val argsResult = args.mapArg1WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			representation1.toEqual("rep 1 modified")
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+		}
+	}
+
+	@Test
+	fun mapArg2() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4"
+		)
+		val argsResult = args.mapArg2 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(null)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+		}
+	}
+
+	@Test
+	fun mapArg2WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4"
+		)
+		val argsResult = args.mapArg2WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual("rep 2 modified")
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+		}
+	}
+
+	@Test
+	fun mapArg3() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4"
+		)
+		val argsResult = args.mapArg3 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(3F)
+			a4.toEqual(args.a4)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(null)
+			representation4.toEqual(args.representation4)
+		}
+	}
+
+	@Test
+	fun mapArg3WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4"
+		)
+		val argsResult = args.mapArg3WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(3F)
+			a4.toEqual(args.a4)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual("rep 3 modified")
+			representation4.toEqual(args.representation4)
+		}
+	}
+
+	@Test
+	fun mapArg4() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4"
+		)
+		val argsResult = args.mapArg4 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(4.0)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(null)
+		}
+	}
+
+	@Test
+	fun mapArg4WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4"
+		)
+		val argsResult = args.mapArg4WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(4.0)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual("rep 4 modified")
+		}
+	}
+
+}

--- a/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args5MapArgTest.kt
+++ b/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args5MapArgTest.kt
@@ -1,0 +1,460 @@
+// --------------------------------------------------------------------------------------------------------------------
+// automatically generated, don't modify here but in:
+// gradle/code-generation/src/main/kotlin/code-generation.generate.gradle.kts
+// --------------------------------------------------------------------------------------------------------------------
+package com.tegonal.minimalist.arguments.mapArg
+
+import ch.tutteli.atrium.api.verbs.expect
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import com.tegonal.minimalist.*
+import com.tegonal.minimalist.atrium.*
+import java.math.BigInteger
+import java.time.LocalDate
+
+class Args5MapArgTest {
+
+	@Test
+	fun mapArg1() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5"
+		)
+		val argsResult = args.mapArg1 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			representation1.toEqual(null)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+		}
+	}
+
+	@Test
+	fun mapArg1WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5"
+		)
+		val argsResult = args.mapArg1WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			representation1.toEqual("rep 1 modified")
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+		}
+	}
+
+	@Test
+	fun mapArg2() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5"
+		)
+		val argsResult = args.mapArg2 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(null)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+		}
+	}
+
+	@Test
+	fun mapArg2WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5"
+		)
+		val argsResult = args.mapArg2WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual("rep 2 modified")
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+		}
+	}
+
+	@Test
+	fun mapArg3() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5"
+		)
+		val argsResult = args.mapArg3 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(3F)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(null)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+		}
+	}
+
+	@Test
+	fun mapArg3WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5"
+		)
+		val argsResult = args.mapArg3WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(3F)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual("rep 3 modified")
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+		}
+	}
+
+	@Test
+	fun mapArg4() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5"
+		)
+		val argsResult = args.mapArg4 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(4.0)
+			a5.toEqual(args.a5)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(null)
+			representation5.toEqual(args.representation5)
+		}
+	}
+
+	@Test
+	fun mapArg4WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5"
+		)
+		val argsResult = args.mapArg4WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(4.0)
+			a5.toEqual(args.a5)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual("rep 4 modified")
+			representation5.toEqual(args.representation5)
+		}
+	}
+
+	@Test
+	fun mapArg5() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5"
+		)
+		val argsResult = args.mapArg5 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual('c')
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(null)
+		}
+	}
+
+	@Test
+	fun mapArg5WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5"
+		)
+		val argsResult = args.mapArg5WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual('c')
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual("rep 5 modified")
+		}
+	}
+
+}

--- a/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args6MapArgTest.kt
+++ b/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args6MapArgTest.kt
@@ -1,0 +1,620 @@
+// --------------------------------------------------------------------------------------------------------------------
+// automatically generated, don't modify here but in:
+// gradle/code-generation/src/main/kotlin/code-generation.generate.gradle.kts
+// --------------------------------------------------------------------------------------------------------------------
+package com.tegonal.minimalist.arguments.mapArg
+
+import ch.tutteli.atrium.api.verbs.expect
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import com.tegonal.minimalist.*
+import com.tegonal.minimalist.atrium.*
+import java.math.BigInteger
+import java.time.LocalDate
+
+class Args6MapArgTest {
+
+	@Test
+	fun mapArg1() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6"
+		)
+		val argsResult = args.mapArg1 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			representation1.toEqual(null)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+		}
+	}
+
+	@Test
+	fun mapArg1WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6"
+		)
+		val argsResult = args.mapArg1WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			representation1.toEqual("rep 1 modified")
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+		}
+	}
+
+	@Test
+	fun mapArg2() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6"
+		)
+		val argsResult = args.mapArg2 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(null)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+		}
+	}
+
+	@Test
+	fun mapArg2WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6"
+		)
+		val argsResult = args.mapArg2WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual("rep 2 modified")
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+		}
+	}
+
+	@Test
+	fun mapArg3() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6"
+		)
+		val argsResult = args.mapArg3 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(3F)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(null)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+		}
+	}
+
+	@Test
+	fun mapArg3WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6"
+		)
+		val argsResult = args.mapArg3WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(3F)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual("rep 3 modified")
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+		}
+	}
+
+	@Test
+	fun mapArg4() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6"
+		)
+		val argsResult = args.mapArg4 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(4.0)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(null)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+		}
+	}
+
+	@Test
+	fun mapArg4WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6"
+		)
+		val argsResult = args.mapArg4WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(4.0)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual("rep 4 modified")
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+		}
+	}
+
+	@Test
+	fun mapArg5() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6"
+		)
+		val argsResult = args.mapArg5 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual('c')
+			a6.toEqual(args.a6)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(null)
+			representation6.toEqual(args.representation6)
+		}
+	}
+
+	@Test
+	fun mapArg5WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6"
+		)
+		val argsResult = args.mapArg5WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual('c')
+			a6.toEqual(args.a6)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual("rep 5 modified")
+			representation6.toEqual(args.representation6)
+		}
+	}
+
+	@Test
+	fun mapArg6() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6"
+		)
+		val argsResult = args.mapArg6 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual("string")
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(null)
+		}
+	}
+
+	@Test
+	fun mapArg6WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6"
+		)
+		val argsResult = args.mapArg6WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual("string")
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual("rep 6 modified")
+		}
+	}
+
+}

--- a/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args7MapArgTest.kt
+++ b/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args7MapArgTest.kt
@@ -1,0 +1,804 @@
+// --------------------------------------------------------------------------------------------------------------------
+// automatically generated, don't modify here but in:
+// gradle/code-generation/src/main/kotlin/code-generation.generate.gradle.kts
+// --------------------------------------------------------------------------------------------------------------------
+package com.tegonal.minimalist.arguments.mapArg
+
+import ch.tutteli.atrium.api.verbs.expect
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import com.tegonal.minimalist.*
+import com.tegonal.minimalist.atrium.*
+import java.math.BigInteger
+import java.time.LocalDate
+
+class Args7MapArgTest {
+
+	@Test
+	fun mapArg1() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7"
+		)
+		val argsResult = args.mapArg1 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			representation1.toEqual(null)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+		}
+	}
+
+	@Test
+	fun mapArg1WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7"
+		)
+		val argsResult = args.mapArg1WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			representation1.toEqual("rep 1 modified")
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+		}
+	}
+
+	@Test
+	fun mapArg2() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7"
+		)
+		val argsResult = args.mapArg2 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(null)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+		}
+	}
+
+	@Test
+	fun mapArg2WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7"
+		)
+		val argsResult = args.mapArg2WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual("rep 2 modified")
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+		}
+	}
+
+	@Test
+	fun mapArg3() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7"
+		)
+		val argsResult = args.mapArg3 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(3F)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(null)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+		}
+	}
+
+	@Test
+	fun mapArg3WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7"
+		)
+		val argsResult = args.mapArg3WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(3F)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual("rep 3 modified")
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+		}
+	}
+
+	@Test
+	fun mapArg4() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7"
+		)
+		val argsResult = args.mapArg4 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(4.0)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(null)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+		}
+	}
+
+	@Test
+	fun mapArg4WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7"
+		)
+		val argsResult = args.mapArg4WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(4.0)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual("rep 4 modified")
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+		}
+	}
+
+	@Test
+	fun mapArg5() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7"
+		)
+		val argsResult = args.mapArg5 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual('c')
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(null)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+		}
+	}
+
+	@Test
+	fun mapArg5WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7"
+		)
+		val argsResult = args.mapArg5WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual('c')
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual("rep 5 modified")
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+		}
+	}
+
+	@Test
+	fun mapArg6() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7"
+		)
+		val argsResult = args.mapArg6 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual("string")
+			a7.toEqual(args.a7)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(null)
+			representation7.toEqual(args.representation7)
+		}
+	}
+
+	@Test
+	fun mapArg6WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7"
+		)
+		val argsResult = args.mapArg6WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual("string")
+			a7.toEqual(args.a7)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual("rep 6 modified")
+			representation7.toEqual(args.representation7)
+		}
+	}
+
+	@Test
+	fun mapArg7() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7"
+		)
+		val argsResult = args.mapArg7 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(LocalDate.now())
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(null)
+		}
+	}
+
+	@Test
+	fun mapArg7WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7"
+		)
+		val argsResult = args.mapArg7WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(LocalDate.now())
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual("rep 7 modified")
+		}
+	}
+
+}

--- a/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args8MapArgTest.kt
+++ b/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args8MapArgTest.kt
@@ -1,0 +1,1012 @@
+// --------------------------------------------------------------------------------------------------------------------
+// automatically generated, don't modify here but in:
+// gradle/code-generation/src/main/kotlin/code-generation.generate.gradle.kts
+// --------------------------------------------------------------------------------------------------------------------
+package com.tegonal.minimalist.arguments.mapArg
+
+import ch.tutteli.atrium.api.verbs.expect
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import com.tegonal.minimalist.*
+import com.tegonal.minimalist.atrium.*
+import java.math.BigInteger
+import java.time.LocalDate
+
+class Args8MapArgTest {
+
+	@Test
+	fun mapArg1() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8"
+		)
+		val argsResult = args.mapArg1 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			representation1.toEqual(null)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+		}
+	}
+
+	@Test
+	fun mapArg1WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8"
+		)
+		val argsResult = args.mapArg1WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			representation1.toEqual("rep 1 modified")
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+		}
+	}
+
+	@Test
+	fun mapArg2() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8"
+		)
+		val argsResult = args.mapArg2 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(null)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+		}
+	}
+
+	@Test
+	fun mapArg2WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8"
+		)
+		val argsResult = args.mapArg2WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual("rep 2 modified")
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+		}
+	}
+
+	@Test
+	fun mapArg3() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8"
+		)
+		val argsResult = args.mapArg3 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(3F)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(null)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+		}
+	}
+
+	@Test
+	fun mapArg3WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8"
+		)
+		val argsResult = args.mapArg3WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(3F)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual("rep 3 modified")
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+		}
+	}
+
+	@Test
+	fun mapArg4() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8"
+		)
+		val argsResult = args.mapArg4 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(4.0)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(null)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+		}
+	}
+
+	@Test
+	fun mapArg4WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8"
+		)
+		val argsResult = args.mapArg4WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(4.0)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual("rep 4 modified")
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+		}
+	}
+
+	@Test
+	fun mapArg5() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8"
+		)
+		val argsResult = args.mapArg5 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual('c')
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(null)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+		}
+	}
+
+	@Test
+	fun mapArg5WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8"
+		)
+		val argsResult = args.mapArg5WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual('c')
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual("rep 5 modified")
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+		}
+	}
+
+	@Test
+	fun mapArg6() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8"
+		)
+		val argsResult = args.mapArg6 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual("string")
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(null)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+		}
+	}
+
+	@Test
+	fun mapArg6WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8"
+		)
+		val argsResult = args.mapArg6WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual("string")
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual("rep 6 modified")
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+		}
+	}
+
+	@Test
+	fun mapArg7() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8"
+		)
+		val argsResult = args.mapArg7 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(LocalDate.now())
+			a8.toEqual(args.a8)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(null)
+			representation8.toEqual(args.representation8)
+		}
+	}
+
+	@Test
+	fun mapArg7WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8"
+		)
+		val argsResult = args.mapArg7WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(LocalDate.now())
+			a8.toEqual(args.a8)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual("rep 7 modified")
+			representation8.toEqual(args.representation8)
+		}
+	}
+
+	@Test
+	fun mapArg8() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8"
+		)
+		val argsResult = args.mapArg8 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(1.toShort())
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(null)
+		}
+	}
+
+	@Test
+	fun mapArg8WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8"
+		)
+		val argsResult = args.mapArg8WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(1.toShort())
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual("rep 8 modified")
+		}
+	}
+
+}

--- a/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args9MapArgTest.kt
+++ b/src/test/generated/kotlin/com/tegonal/minimalist/arguments/mapArg/Args9MapArgTest.kt
@@ -1,0 +1,1244 @@
+// --------------------------------------------------------------------------------------------------------------------
+// automatically generated, don't modify here but in:
+// gradle/code-generation/src/main/kotlin/code-generation.generate.gradle.kts
+// --------------------------------------------------------------------------------------------------------------------
+package com.tegonal.minimalist.arguments.mapArg
+
+import ch.tutteli.atrium.api.verbs.expect
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import com.tegonal.minimalist.*
+import com.tegonal.minimalist.atrium.*
+import java.math.BigInteger
+import java.time.LocalDate
+
+class Args9MapArgTest {
+
+	@Test
+	fun mapArg1() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg1 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			representation1.toEqual(null)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+		}
+	}
+
+	@Test
+	fun mapArg1WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg1WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			representation1.toEqual("rep 1 modified")
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+		}
+	}
+
+	@Test
+	fun mapArg2() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg2 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(null)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+		}
+	}
+
+	@Test
+	fun mapArg2WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg2WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(2L)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual("rep 2 modified")
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+		}
+	}
+
+	@Test
+	fun mapArg3() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg3 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(3F)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(null)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+		}
+	}
+
+	@Test
+	fun mapArg3WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg3WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(3F)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual("rep 3 modified")
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+		}
+	}
+
+	@Test
+	fun mapArg4() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg4 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(4.0)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(null)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+		}
+	}
+
+	@Test
+	fun mapArg4WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg4WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(4.0)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual("rep 4 modified")
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+		}
+	}
+
+	@Test
+	fun mapArg5() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg5 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual('c')
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(null)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+		}
+	}
+
+	@Test
+	fun mapArg5WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg5WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual('c')
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual("rep 5 modified")
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+		}
+	}
+
+	@Test
+	fun mapArg6() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg6 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual("string")
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(null)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+		}
+	}
+
+	@Test
+	fun mapArg6WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg6WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual("string")
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual("rep 6 modified")
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+		}
+	}
+
+	@Test
+	fun mapArg7() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg7 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(LocalDate.now())
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(null)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+		}
+	}
+
+	@Test
+	fun mapArg7WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg7WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(LocalDate.now())
+			a8.toEqual(args.a8)
+			a9.toEqual(args.a9)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual("rep 7 modified")
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(args.representation9)
+		}
+	}
+
+	@Test
+	fun mapArg8() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg8 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(1.toShort())
+			a9.toEqual(args.a9)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(null)
+			representation9.toEqual(args.representation9)
+		}
+	}
+
+	@Test
+	fun mapArg8WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg8WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(1.toShort())
+			a9.toEqual(args.a9)
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual("rep 8 modified")
+			representation9.toEqual(args.representation9)
+		}
+	}
+
+	@Test
+	fun mapArg9() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg9 { it.first() }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(2.toByte())
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual(null)
+		}
+	}
+
+	@Test
+	fun mapArg9WithRepresentation() {
+		val args = Args.of(
+			listOf(1),
+			listOf(2L),
+			listOf(3F),
+			listOf(4.0),
+			listOf('c'),
+			listOf("string"),
+			listOf(LocalDate.now()),
+			listOf(1.toShort()),
+			listOf(2.toByte()),
+			representation1 = Representation("rep 1"),
+			representation2 = "rep 2",
+			representation3 = "rep 3",
+			representation4 = "rep 4",
+			representation5 = "rep 5",
+			representation6 = "rep 6",
+			representation7 = "rep 7",
+			representation8 = "rep 8",
+			representation9 = "rep 9"
+		)
+		val argsResult = args.mapArg9WithRepresentation { arg, repr -> arg.first() to "$repr modified" }
+
+		// no changes to args
+		expect(args) {
+			a1.toEqual(listOf(1))
+			a2.toEqual(listOf(2L))
+			a3.toEqual(listOf(3F))
+			a4.toEqual(listOf(4.0))
+			a5.toEqual(listOf('c'))
+			a6.toEqual(listOf("string"))
+			a7.toEqual(listOf(LocalDate.now()))
+			a8.toEqual(listOf(1.toShort()))
+			a9.toEqual(listOf(2.toByte()))
+			representation1.toEqual("rep 1")
+			representation2.toEqual("rep 2")
+			representation3.toEqual("rep 3")
+			representation4.toEqual("rep 4")
+			representation5.toEqual("rep 5")
+			representation6.toEqual("rep 6")
+			representation7.toEqual("rep 7")
+			representation8.toEqual("rep 8")
+			representation9.toEqual("rep 9")
+		}
+
+		expect(argsResult) {
+			a1.toEqual(args.a1)
+			a2.toEqual(args.a2)
+			a3.toEqual(args.a3)
+			a4.toEqual(args.a4)
+			a5.toEqual(args.a5)
+			a6.toEqual(args.a6)
+			a7.toEqual(args.a7)
+			a8.toEqual(args.a8)
+			a9.toEqual(2.toByte())
+			representation1.toEqual(args.representation1)
+			representation2.toEqual(args.representation2)
+			representation3.toEqual(args.representation3)
+			representation4.toEqual(args.representation4)
+			representation5.toEqual(args.representation5)
+			representation6.toEqual(args.representation6)
+			representation7.toEqual(args.representation7)
+			representation8.toEqual(args.representation8)
+			representation9.toEqual("rep 9 modified")
+		}
+	}
+
+}


### PR DESCRIPTION
as complement of withArgX which does not allow to change the arg type. Next logic step would be to provide a `replace` which does not expect a lambda but just a value and representation. But I will first see if I need this often enough so that an own method is justified.



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/minimalist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
