### PR TITLE
flatten ArgsRangeOptions in config, keep requestedMinArgs/atMostArgs

### DIFF
--- a/src/main/kotlin/com/tegonal/minimalist/config/impl/MinimalistConfigViaPropertiesLoader.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/config/impl/MinimalistConfigViaPropertiesLoader.kt
@@ -17,7 +17,16 @@ class MinimalistConfigViaPropertiesLoader {
 			.run {
 				mergeWithPropertiesInResource("/minimalist.properties", parser).also {
 					check(it.seed == initialConfig.seed) {
-						"You are not allowed to modify the seed via minimalist.properties use minimalist.local.properties to fix a seed"
+						errorMessageNotAllowedToModify("seed")
+					}
+					check(it.offsetToDecidedOffset == initialConfig.offsetToDecidedOffset) {
+						errorMessageNotAllowedToModify("offsetToDecidedOffset")
+					}
+					check(it.requestedMinArgs == initialConfig.requestedMinArgs) {
+						errorMessageNotAllowedToModify("requestedMinArgs")
+					}
+					check(it.atMostArgs == initialConfig.atMostArgs) {
+						errorMessageNotAllowedToModify("atMostArgs")
 					}
 				}
 			}.run { mergeWithPropertiesInResource("/minimalist.local.properties", parser) }
@@ -35,6 +44,9 @@ class MinimalistConfigViaPropertiesLoader {
 				// would be simpler if they could just set the DateTime in errorAboutFixedSeedAt
 			}
 	}
+
+	private fun errorMessageNotAllowedToModify(what: String) =
+		"You are not allowed to modify $what via minimalist.properties use minimalist.local.properties to fix a seed"
 
 	private fun MinimalistConfig.mergeWithPropertiesInResource(
 		propertiesFile: String,

--- a/src/main/kotlin/com/tegonal/minimalist/providers/impl/BaseArgsRangeOptionsBasedArgsRangeDecider.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/impl/BaseArgsRangeOptionsBasedArgsRangeDecider.kt
@@ -26,11 +26,9 @@ abstract class BaseArgsRangeOptionsBasedArgsRangeDecider : ArgsRangeDecider {
 
 	final override fun decide(argsGenerator: ArgsGenerator<*>, argsRangeOptions: ArgsRangeOptions?): ArgsRange {
 		val config = argsGenerator._components.config
-		val category = config.argsRangeOptions.profile
-			?: argsRangeOptions?.profile
-			?: config.defaultProfile
+		val profile = argsRangeOptions?.profile ?: config.defaultProfile
 
-		return decideArgsRange(category, config.activeEnv, argsGenerator)
+		return decideArgsRange(profile, config.activeEnv, argsGenerator)
 			.restrictBasedOnConfigAndArgsRangeOptions(config, argsRangeOptions, argsGenerator)
 
 	}
@@ -38,7 +36,7 @@ abstract class BaseArgsRangeOptionsBasedArgsRangeDecider : ArgsRangeDecider {
 	/**
 	 * Returns the [ArgsRange] solely based on the given [profileName], [env] and [argsGenerator].
 	 *
-	 * Restricting the choice based on given [ArgsRangeOptions] or [MinimalistConfig.argsRangeOptions] is the
+	 * Restricting the choice based on given [ArgsRangeOptions] and [MinimalistConfig] is the
 	 * responsibility of [BaseArgsRangeOptionsBasedArgsRangeDecider].
 	 */
 	protected abstract fun decideArgsRange(
@@ -56,8 +54,8 @@ abstract class BaseArgsRangeOptionsBasedArgsRangeDecider : ArgsRangeDecider {
 		run {
 			config.offsetToDecidedOffset?.let { this.copy(offset = this.offset + it) } ?: this
 		}.let { argsRange ->
-			val atMostArgs = config.argsRangeOptions.atMostArgs ?: argsRangeOptions?.atMostArgs
-			val requestedMinArgs = config.argsRangeOptions.requestedMinArgs ?: argsRangeOptions?.requestedMinArgs
+			val atMostArgs = config.atMostArgs ?: argsRangeOptions?.atMostArgs
+			val requestedMinArgs = config.requestedMinArgs ?: argsRangeOptions?.requestedMinArgs
 			val generatorSize = maybeGeneratorSize(argsGenerator)
 
 			val newTake = argsRange.take.letIf(atMostArgs != null) {


### PR DESCRIPTION
we already have defaultProfile in config, doesn't make sense that one can override it via ArgsRangeOptions. And there might be more properties in the future which only make sense to be overridden for a class/test method.

Moreover:
- fail if one configures offsetToDecidedOffset, requestedMinArgs, atMostArgs in minimalist.properties.



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/minimalist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
