### PR TITLE
fix int/longSafeMinMax should have used intFromUntil instead of FromTo

### DIFF
--- a/src/test/kotlin/com/tegonal/minimalist/generators/ArbBoundsTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/ArbBoundsTest.kt
@@ -131,7 +131,7 @@ class ArbBoundsTest : AbstractArbArgsGeneratorTest<Any>() {
 		fun intSafeMinMax() =
 			// we are not using arb.intRange here on purpose as we would use the function under test in the test-setup
 			arb.intFromUntil(Int.MIN_VALUE, Int.MAX_VALUE - possibleMaxSizeSafeInIntDomain).combineDependent {
-				arb.intFromTo(it, it + possibleMaxSizeSafeInIntDomain)
+				arb.intFromUntil(it, it + possibleMaxSizeSafeInIntDomain)
 			}
 
 		@JvmStatic
@@ -145,7 +145,7 @@ class ArbBoundsTest : AbstractArbArgsGeneratorTest<Any>() {
 			// we are not using arb.longRange here on purpose as we would use the function under test in the test-setup
 			arb.longFromUntil(Long.MIN_VALUE, Long.MAX_VALUE - possibleMaxSizeSafeInLongDomain).combineDependent {
 				// + possibleMaxSizeSafeInIntDomain as we could otherwise land in the Int-Domain
-				arb.longFromTo(it + possibleMaxSizeSafeInIntDomain, it + possibleMaxSizeSafeInLongDomain)
+				arb.longFromUntil(it + possibleMaxSizeSafeInIntDomain, it + possibleMaxSizeSafeInLongDomain)
 			}
 
 		@JvmStatic


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/minimalist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
