### PR TITLE
rename toRandomArgsGenerator to toArb... move into OrderedArgsGenerator

### DIFF
--- a/src/main/kotlin/com/tegonal/minimalist/generators/ArbArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/ArbArgsGenerator.kt
@@ -21,6 +21,13 @@ import com.tegonal.minimalist.utils.createMinimalistRandom
 //  return all values in case an ArgsRangeDecider decides to take more then the available size
 interface ArbArgsGenerator<out T> : ArgsGenerator<T> {
 	/**
+	 * Returns one random value of type [T].
+	 *
+	 * @since 2.0.0
+	 */
+	fun generateOne(seedOffset: Int = 0): T = generate(seedOffset).first()
+
+	/**
 	 * Generates an infinite stream of random values of type [T].
 	 *
 	 * @param seedOffset an offset to [MinimalistConfig.seed] which shall be applied in

--- a/src/main/kotlin/com/tegonal/minimalist/generators/OrderedArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/OrderedArgsGenerator.kt
@@ -43,6 +43,6 @@ interface OrderedArgsGenerator<out T> : SemiOrderedArgsGenerator<T> {
 			seedBaseOffset = 0,
 			from = 0,
 			toExclusive = size
-		).map { offset -> this.generate(offset).first() }
+		).map { offset -> this.generateOne(offset) }
 }
 

--- a/src/main/kotlin/com/tegonal/minimalist/generators/SemiOrderedArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/SemiOrderedArgsGenerator.kt
@@ -18,6 +18,13 @@ interface SemiOrderedArgsGenerator<out T> : ArgsGenerator<T> {
 	val size: Int
 
 	/**
+	 * Returns the value at the given [offset].
+	 *
+	 * @since 2.0.0
+	 */
+	fun generateOne(offset: Int = 0): T = generate(offset).first()
+
+	/**
 	 * Returns an infinite stream of values starting at [offset] and repeating after reaching [size] of values
 	 * where one part of the values are always the same when generated multiple times.
 	 *

--- a/src/main/kotlin/com/tegonal/minimalist/generators/arbCombine.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/arbCombine.kt
@@ -48,10 +48,5 @@ fun <A1, A2, R> ArbArgsGenerator<A1>.combineDependent(
 	transform: (A1, A2) -> R
 ): ArbArgsGenerator<R> =
 	this.mapIndexed { index, it, seedOffset ->
-		transform(
-			it,
-			//TODO 2.1.0 introduce ArbArgsGenerator.generateOne, this way ArbArgsGenerators can provide a more efficient
-			// way it they like, (instead of creating a sequence and then using first() and then drop the sequence)
-			this._core.arb.otherFactory(it).generate(index + seedOffset).first()
-		)
+		transform(it, this._core.arb.otherFactory(it).generateOne(index + seedOffset))
 	}

--- a/src/main/kotlin/com/tegonal/minimalist/generators/impl/ArrayOrderedArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/impl/ArrayOrderedArgsGenerator.kt
@@ -2,6 +2,7 @@ package com.tegonal.minimalist.generators.impl
 
 import com.tegonal.minimalist.config.ComponentFactoryContainer
 import com.tegonal.minimalist.generators.OrderedArgsGenerator
+import com.tegonal.minimalist.utils.impl.determineStartingIndex
 import com.tegonal.minimalist.utils.repeatForever
 
 /**
@@ -16,6 +17,11 @@ class ArrayOrderedArgsGenerator<T>(
 	componentFactoryContainer: ComponentFactoryContainer,
 	private val values: Array<T>
 ) : BaseSemiOrderedArgsGenerator<T>(componentFactoryContainer, values.size), OrderedArgsGenerator<T> {
+
+	override fun generateOneAfterChecks(offset: Int): T {
+		val index = determineStartingIndex(0, size, offset, 1)
+		return values[index]
+	}
 
 	override fun generateAfterChecks(offset: Int): Sequence<T> =
 		repeatForever(values, offset)

--- a/src/main/kotlin/com/tegonal/minimalist/generators/impl/BaseSemiOrderedArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/impl/BaseSemiOrderedArgsGenerator.kt
@@ -41,12 +41,23 @@ abstract class BaseSemiOrderedArgsGenerator<T>(
 		checkIsPositive(size, "size")
 	}
 
+	final override fun generateOne(offset: Int): T {
+		checkOffset(offset)
+		return generateOneAfterChecks(offset)
+	}
+
 	final override fun generate(offset: Int): Sequence<T> {
-		check(offset >= 0) {
-			"minus offsets are not supported, given $offset"
-		}
+		checkOffset(offset)
 		return generateAfterChecks(offset)
 	}
+
+	private fun checkOffset(offset: Int) {
+		check(offset >= 0) {
+			"negative offsets are not supported, given $offset"
+		}
+	}
+
+	open fun generateOneAfterChecks(offset: Int): T = generateAfterChecks(offset).first()
 
 	abstract fun generateAfterChecks(offset: Int): Sequence<T>
 }

--- a/src/main/kotlin/com/tegonal/minimalist/generators/impl/ListOrderedArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/impl/ListOrderedArgsGenerator.kt
@@ -2,6 +2,7 @@ package com.tegonal.minimalist.generators.impl
 
 import com.tegonal.minimalist.config.ComponentFactoryContainer
 import com.tegonal.minimalist.generators.OrderedArgsGenerator
+import com.tegonal.minimalist.utils.impl.determineStartingIndex
 import com.tegonal.minimalist.utils.repeatForever
 
 /**
@@ -16,6 +17,11 @@ class ListOrderedArgsGenerator<T>(
 	componentFactoryContainer: ComponentFactoryContainer,
 	private val values: List<T>
 ) : BaseSemiOrderedArgsGenerator<T>(componentFactoryContainer, values.size), OrderedArgsGenerator<T> {
+
+	override fun generateOneAfterChecks(offset: Int): T {
+		val index = determineStartingIndex(0, size, offset, 1)
+		return values[index]
+	}
 
 	override fun generateAfterChecks(offset: Int): Sequence<T> =
 		repeatForever(values, offset)

--- a/src/main/kotlin/com/tegonal/minimalist/generators/impl/OrderedArgsGeneratorTransformer.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/impl/OrderedArgsGeneratorTransformer.kt
@@ -2,7 +2,6 @@ package com.tegonal.minimalist.generators.impl
 
 import com.tegonal.minimalist.generators.OrderedArgsGenerator
 
-
 /**
  * !! No backward compatibility guarantees !!
  * Reuse at your own risk

--- a/src/main/kotlin/com/tegonal/minimalist/generators/impl/RandomAccessOrderedArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/impl/RandomAccessOrderedArgsGenerator.kt
@@ -3,6 +3,7 @@ package com.tegonal.minimalist.generators.impl
 import com.tegonal.minimalist.config.ComponentFactoryContainer
 import com.tegonal.minimalist.generators.OrderedArgsGenerator
 import com.tegonal.minimalist.utils.impl.RepeatingRandomAccessSequence
+import com.tegonal.minimalist.utils.impl.determineStartingIndex
 
 /**
  * Represents a class for [OrderedArgsGenerator] which provide fast random access.
@@ -17,6 +18,11 @@ class RandomAccessOrderedArgsGenerator<T>(
 	size: Int,
 	private val elementAt: (index: Int) -> T
 ) : BaseSemiOrderedArgsGenerator<T>(componentFactoryContainer, size), OrderedArgsGenerator<T> {
+
+	override fun generateOneAfterChecks(offset: Int): T {
+		val index = determineStartingIndex(0, size, offset, 1)
+		return elementAt(index)
+	}
 
 	override fun generateAfterChecks(offset: Int): Sequence<T> =
 		RepeatingRandomAccessSequence(size, offset, elementAt)

--- a/src/main/kotlin/com/tegonal/minimalist/generators/impl/RandomBasedArbArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/impl/RandomBasedArbArgsGenerator.kt
@@ -15,6 +15,10 @@ abstract class RandomBasedArbArgsGenerator<T>(
 	seedBaseOffset: Int,
 ) : BaseArbArgsGenerator<T>(componentFactoryContainer, seedBaseOffset) {
 
+	override fun generateOne(seedOffset: Int): T =
+		// Random is not thread safe, add synchronisation in case we run into issues
+		createMinimalistRandom(seedOffset).nextElement()
+
 	override fun generate(seedOffset: Int): Sequence<T> = createMinimalistRandom(seedOffset).let { random ->
 		repeatForever().map {
 			// Random is not thread safe, add synchronisation in case we run into issues

--- a/src/main/kotlin/com/tegonal/minimalist/generators/impl/arbArgsGeneratorMergers.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/impl/arbArgsGeneratorMergers.kt
@@ -30,6 +30,12 @@ class ArbArgsGeneratorMerger<T>(
 		checkIsPositive(a2GeneratorWithWeight.first, "(2.) weight")
 	}
 
+	override fun generateOne(seedOffset: Int): T = createMinimalistRandom(seedOffset).let { minimalistRandom ->
+		val r = minimalistRandom.nextInt(1, totalWeightPlus1)
+		return if (r <= a1Weight) a1Generator.generateOne(seedOffset)
+		else a2Generator.generateOne(seedOffset)
+	}
+
 	override fun generate(seedOffset: Int): Sequence<T> = createMinimalistRandom(seedOffset).let { minimalistRandom ->
 		Sequence {
 			object : Iterator<T> {
@@ -98,6 +104,12 @@ class MultiArbArgsGeneratorIndexOfMerger<T>(
 		}
 
 		totalWeightPlus1 = Math.addExact(acc, 1)
+	}
+
+	override fun generateOne(seedOffset: Int): T = createMinimalistRandom(seedOffset).let { minimalistRandom ->
+		val r = minimalistRandom.nextInt(1, totalWeightPlus1)
+		val index = cumulativeWeights.indexOfFirst { it >= r }
+		generators[index].generateOne(seedOffset)
 	}
 
 	override fun generate(seedOffset: Int): Sequence<T> = createMinimalistRandom(seedOffset).let { minimalistRandom ->

--- a/src/main/kotlin/com/tegonal/minimalist/generators/impl/orderedArgsGeneratorCombiners.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/impl/orderedArgsGeneratorCombiners.kt
@@ -22,6 +22,8 @@ class OrderedArgsGeneratorCombiner<A1, A2, R>(
 	a1Generator.size.toLong() * a2Generator.size.toLong()
 ), OrderedArgsGenerator<R> {
 
+	//TODO 2.1.0 override generateOneAfterChecks?
+
 	override fun generateAfterChecks(offset: Int): Sequence<R> =
 		combine(a1Generator, a2Generator, transform, offset)
 }

--- a/src/main/kotlin/com/tegonal/minimalist/generators/impl/orderedArgsGeneratorConcatenators.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/impl/orderedArgsGeneratorConcatenators.kt
@@ -20,6 +20,16 @@ class OrderedArgsGeneratorConcatenator<T>(
 	a1Generator._components,
 	a1Generator.size.toLong() + a2Generator.size.toLong()
 ), OrderedArgsGenerator<T> {
+	
+	override fun generateOneAfterChecks(offset: Int): T {
+		val offsetInRange = offset % size
+		val a1Size = a1Generator.size
+		return if (offsetInRange < a1Size) {
+			a1Generator.generateOne(offsetInRange)
+		} else {
+			a2Generator.generateOne(offsetInRange - a1Size)
+		}
+	}
 
 	override fun generateAfterChecks(offset: Int): Sequence<T> =
 		concatenate(a1Generator, a2Generator, size, offset)

--- a/src/main/kotlin/com/tegonal/minimalist/generators/impl/orderedNumberGenerators.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/impl/orderedNumberGenerators.kt
@@ -8,6 +8,7 @@ import com.tegonal.minimalist.utils.impl.BigIntFromUntilRepeatingIterator
 import com.tegonal.minimalist.utils.impl.IntFromUntilRepeatingIterator
 import com.tegonal.minimalist.utils.impl.LongFromUntilRepeatingIterator
 import com.tegonal.minimalist.utils.impl.checkRangeNumbers
+import com.tegonal.minimalist.utils.impl.determineStartingIndex
 import com.tegonal.minimalist.utils.toBigInt
 
 /**
@@ -31,6 +32,12 @@ class IntFromUntilOrderedArgsGenerator(
 		calculatedRangeSizeToArgsGeneratorSize(from.toLong(), toExclusive.toLong(), step.toLong())
 	}
 ), OrderedArgsGenerator<Int> {
+
+	override fun generateOneAfterChecks(offset: Int): Int {
+		checkRangeNumbers(from, toExclusive, offset, step)
+		// index = value so we can directly return it
+		return determineStartingIndex(from, toExclusive, offset, step)
+	}
 
 	override fun generateAfterChecks(offset: Int): Sequence<Int> = Sequence {
 		IntFromUntilRepeatingIterator(from, toExclusive, offset = offset, step = step)
@@ -62,6 +69,15 @@ class LongFromUntilOrderedArgsGenerator(
 	}
 ), OrderedArgsGenerator<Long> {
 
+	override fun generateOneAfterChecks(offset: Int): Long {
+		checkRangeNumbers(from, toExclusive, offset.toLong(), step)
+		// index = value so we can directly return it
+		return determineStartingIndex(
+			// toExclusive - from could overflow, so we use BigInt
+			from.toBigInt(), toExclusive.toBigInt(), offset.toBigInt(), step.toBigInt()
+		).toLong()
+	}
+
 	override fun generateAfterChecks(offset: Int): Sequence<Long> = Sequence {
 		LongFromUntilRepeatingIterator(from, toExclusive, offset = offset.toLong(), step = step)
 	}
@@ -88,11 +104,16 @@ class BigIntFromUntilOrderedArgsGenerator(
 	}
 ), OrderedArgsGenerator<BigInt> {
 
+	override fun generateOneAfterChecks(offset: Int): BigInt {
+		val offsetBigInt = offset.toBigInt()
+		checkRangeNumbers(from, toExclusive, offsetBigInt, step)
+		return determineStartingIndex(from, toExclusive, offsetBigInt, step)
+	}
+
 	override fun generateAfterChecks(offset: Int): Sequence<BigInt> = Sequence {
 		BigIntFromUntilRepeatingIterator(from, toExclusive, offset = offset.toBigInt(), step = step)
 	}
 }
-
 
 private fun calculatedRangeSizeToArgsGeneratorSize(
 	from: Long,

--- a/src/main/kotlin/com/tegonal/minimalist/providers/impl/BaseArgsRangeOptionsBasedArgsRangeDecider.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/impl/BaseArgsRangeOptionsBasedArgsRangeDecider.kt
@@ -46,7 +46,6 @@ abstract class BaseArgsRangeOptionsBasedArgsRangeDecider : ArgsRangeDecider {
 		argsGenerator: ArgsGenerator<*>
 	): ArgsRange
 
-
 	private fun ArgsRange.restrictBasedOnConfigAndArgsRangeOptions(
 		config: MinimalistConfig,
 		argsRangeOptions: ArgsRangeOptions?,

--- a/src/main/kotlin/com/tegonal/minimalist/utils/impl/baseRepeatingIterators.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/utils/impl/baseRepeatingIterators.kt
@@ -41,7 +41,7 @@ abstract class BaseIntFromUntilRepeatingIterator<T>(
 
 	init {
 		checkRangeNumbers(from, toExclusive, offset, step)
-		index = determineStartingIndex(from.toLong(), toExclusive.toLong(), offset.toLong(), step.toLong()).toInt()
+		index = determineStartingIndex(from, toExclusive, offset, step)
 	}
 
 	override fun hasNext() = true
@@ -124,8 +124,17 @@ abstract class BaseBigIntFromUntilRepeatingIterator<T>(
 	abstract fun getElementAt(index: BigInt): T
 }
 
+/**
+ * Convenience method which convert to [Long] and then calls determineStartingIndex and converts the result back to Int
+ */
+fun determineStartingIndex(
+	from: Int,
+	toExclusive: Int,
+	offset: Int,
+	step: Int
+): Int = determineStartingIndex(from.toLong(), toExclusive.toLong(), offset.toLong(), step.toLong()).toInt()
 
-private fun determineStartingIndex(
+fun determineStartingIndex(
 	from: Long,
 	toExclusive: Long,
 	offset: Long,
@@ -143,7 +152,7 @@ private fun determineStartingIndex(
 	1
 )
 
-private fun determineStartingIndex(
+fun determineStartingIndex(
 	from: BigInt,
 	toExclusive: BigInt,
 	offset: BigInt,

--- a/src/main/kotlin/com/tegonal/minimalist/utils/randomHelpers.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/utils/randomHelpers.kt
@@ -3,8 +3,9 @@ package com.tegonal.minimalist.utils
 import com.tegonal.minimalist.config.MinimalistConfig
 import com.tegonal.minimalist.config._components
 import com.tegonal.minimalist.config.createMinimalistRandom
-import com.tegonal.minimalist.utils.impl.checkIsPositive
+import com.tegonal.minimalist.generators.SemiOrderedArgsGenerator
 import com.tegonal.minimalist.generators.ordered
+import com.tegonal.minimalist.utils.impl.checkIsPositive
 import com.tegonal.minimalist.utils.impl.requireFromLessThanToExclusive
 import java.math.BigInteger
 import kotlin.random.Random
@@ -14,7 +15,7 @@ import kotlin.random.asJavaRandom
  * Picks randomly one element from `this` [Collection] based on the configured [MinimalistConfig.seed]
  * @since 2.0.0
  */
-fun <T> Collection<T>.pickRandomly(): T =
+fun <T> Collection<T>.pickOneRandomly(): T =
 	when (val size = size) {
 		0 -> error("this Collection is empty, we cannot pick randomly an element from it")
 		1 -> first()
@@ -37,7 +38,7 @@ fun <T> Collection<T>.pickRandomly(): T =
  * Picks randomly one element from `this` [Collection] based on the configured [MinimalistConfig.seed].
  * @since 2.0.0
  */
-fun <T> Array<T>.pickRandomly(): T =
+fun <T> Array<T>.pickOneRandomly(): T =
 	when (val size = size) {
 		0 -> error("this Array is empty, we cannot pick randomly an element from it")
 		1 -> first()
@@ -47,6 +48,14 @@ fun <T> Array<T>.pickRandomly(): T =
 		}
 	}
 
+/**
+ * Picks randomly one element from `this` [SemiOrderedArgsGenerator] based on the configured [MinimalistConfig.seed].
+ * @since 2.0.0
+ */
+fun <T> SemiOrderedArgsGenerator<T>.pickOneRandomly(seedOffset: Int = 0): T =
+	_components.createMinimalistRandom(seedOffset).nextInt(0, size).let { offset ->
+		generateOne(offset)
+	}
 
 /**
  * Takes the given [amount] of elements from `this` [Iterable] (likewise [Iterable.take]) but in a random way

--- a/src/main/kotlin/com/tegonal/minimalist/utils/sequenceHelpers.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/utils/sequenceHelpers.kt
@@ -16,7 +16,6 @@ fun repeatForever(): Sequence<Unit> = ForeverUnitSequence()
  */
 fun <T> repeatForever(list: List<T>, offset: Int = 0): Sequence<T> = RepeatingListSequence(list, offset)
 
-
 /**
  * Returns an infinite [Sequence] backed by the given [array], starting at the given [offset].
  * @since 2.0.0

--- a/src/test/kotlin/com/tegonal/minimalist/generators/AbstractArbArgsGeneratorTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/AbstractArbArgsGeneratorTest.kt
@@ -8,6 +8,7 @@ import ch.tutteli.kbox.a2
 import ch.tutteli.kbox.mapA3
 import com.tegonal.minimalist.config.arb
 import com.tegonal.minimalist.generators.impl.DefaultArbExtensionPoint
+import org.junit.jupiter.api.Test
 
 typealias ArbArgsTestFactoryResult<T> = ArgsTestFactoryResult<T, ArbArgsGenerator<T>>
 
@@ -58,4 +59,12 @@ abstract class AbstractArbArgsGeneratorTest<T>() : AbstractArbArgsGeneratorWitho
 	@TestFactory
 	fun canAlwaysTakeTheDesiredAmount() =
 		canAlwaysTakeTheDesiredAmountTest({ createGenerators(customComponentFactoryContainer.arb) }) { it.generate() }
+
+	@TestFactory
+	fun generateOneIsTheSameAsGenerateFirst() =
+		generateOneIsTheSameAsGenerateFirstTest(
+			factory = { createGenerators(customComponentFactoryContainer.arb) },
+			generateOne = { it.generateOne() },
+			generate = { it.generate() }
+		)
 }

--- a/src/test/kotlin/com/tegonal/minimalist/generators/AbstractArgsGeneratorTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/AbstractArgsGeneratorTest.kt
@@ -16,7 +16,7 @@ typealias ArgsTestFactoryResult<T, ArgsGeneratorT> = Sequence<Triple<String, Arg
 
 const val maxTakeInCanAlwaysTakeTheDesiredAmountTest = 200
 
-abstract class AbstractArgsGeneratorTest: BaseTest() {
+abstract class AbstractArgsGeneratorTest : BaseTest() {
 	protected val customComponentFactoryContainer =
 		ComponentFactoryContainer.createBasedOnConfig(ordered._components.config)
 
@@ -49,6 +49,14 @@ abstract class AbstractArgsGeneratorTest: BaseTest() {
 			++count
 		}
 		expect(count).toEqual(take)
+	}
+
+	protected fun <T, ArgsGeneratorT : ArgsGenerator<T>, TestResultT : ArgsTestFactoryResult<T, ArgsGeneratorT>> generateOneIsTheSameAsGenerateFirstTest(
+		factory: () -> TestResultT,
+		generateOne: (ArgsGeneratorT) -> T,
+		generate: (ArgsGeneratorT) -> Sequence<T>
+	) = testFactory(factory) { generator, _, _ ->
+		expect(generateOne(generator)).toEqual(generate(generator).first())
 	}
 
 	protected fun <T, ArgGeneratorT : ArgsGenerator<T>, TestResulT : ArgsTestFactoryResult<T, ArgGeneratorT>> testFactory(

--- a/src/test/kotlin/com/tegonal/minimalist/generators/AbstractOrderedArgsGeneratorTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/AbstractOrderedArgsGeneratorTest.kt
@@ -6,7 +6,9 @@ import ch.tutteli.atrium.api.verbs.expectGrouped
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.testfactories.TestFactory
 import com.tegonal.minimalist.config._components
+import com.tegonal.minimalist.config.arb
 import com.tegonal.minimalist.config.config
+import com.tegonal.minimalist.config.ordered
 import com.tegonal.minimalist.generators.impl.DefaultOrderedExtensionPoint
 import com.tegonal.minimalist.utils.createMinimalistRandom
 import kotlin.math.absoluteValue
@@ -90,6 +92,14 @@ abstract class AbstractOrderedArgsGeneratorTest<T>() : AbstractOrderedArgsGenera
 
 	@TestFactory
 	fun canAlwaysTakeTheDesiredAmount() = canAlwaysTakeTheDesiredAmountTest(::createGenerators)
+
+	@TestFactory
+	fun generateOneIsTheSameAsGenerateFirst() =
+		generateOneIsTheSameAsGenerateFirstTest(
+			factory = { createGenerators() },
+			generateOne = { it.generateOne(customComponentFactoryContainer.config.seed.absoluteValue) },
+			generate = { it.generate(customComponentFactoryContainer.config.seed.absoluteValue) }
+		)
 
 	@TestFactory
 	fun coversAllCases() = coversAllCasesTest(::createGenerators)


### PR DESCRIPTION
this way a subclass could override it to provide a more efficient way



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/minimalist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
