### PR TITLE
fix ArgsArgumentProvider, nested tuples shall be flattened and split

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ description = "Library which helps to setup and prioritise parameterized tests"
 
 dependencies {
 	api(libs.junit.jupiter.params)
-	implementation(libs.kbox)
+	api(libs.kbox)
 	implementation(kotlin("reflect"))
 
 	testImplementation(kotlin("test"))

--- a/src/main/kotlin/com/tegonal/minimalist/generators/impl/orderedNumberGenerators.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/impl/orderedNumberGenerators.kt
@@ -34,7 +34,6 @@ class IntFromUntilOrderedArgsGenerator(
 ), OrderedArgsGenerator<Int> {
 
 	override fun generateOneAfterChecks(offset: Int): Int {
-		checkRangeNumbers(from, toExclusive, offset, step)
 		// index = value so we can directly return it
 		return determineStartingIndex(from, toExclusive, offset, step)
 	}
@@ -70,7 +69,6 @@ class LongFromUntilOrderedArgsGenerator(
 ), OrderedArgsGenerator<Long> {
 
 	override fun generateOneAfterChecks(offset: Int): Long {
-		checkRangeNumbers(from, toExclusive, offset.toLong(), step)
 		// index = value so we can directly return it
 		return determineStartingIndex(
 			// toExclusive - from could overflow, so we use BigInt
@@ -105,9 +103,8 @@ class BigIntFromUntilOrderedArgsGenerator(
 ), OrderedArgsGenerator<BigInt> {
 
 	override fun generateOneAfterChecks(offset: Int): BigInt {
-		val offsetBigInt = offset.toBigInt()
-		checkRangeNumbers(from, toExclusive, offsetBigInt, step)
-		return determineStartingIndex(from, toExclusive, offsetBigInt, step)
+		// index = value so we can directly return it
+		return determineStartingIndex(from, toExclusive, offset.toBigInt(), step)
 	}
 
 	override fun generateAfterChecks(offset: Int): Sequence<BigInt> = Sequence {

--- a/src/main/kotlin/com/tegonal/minimalist/providers/impl/DefaultGenericToArgsGeneratorConverter.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/impl/DefaultGenericToArgsGeneratorConverter.kt
@@ -28,7 +28,7 @@ class DefaultGenericToArgsGeneratorConverter : GenericToArgsGeneratorConverter {
 						list.also { it.add(aNext) }
 					}
 
-					is SemiOrderedArgsGenerator<*> -> error("wrong ordering of ArgsGenerators, make sure at leat one (Semi)OrderedArgsGenerators come before a RandomArgsGenerator<*>")
+					is SemiOrderedArgsGenerator<*> -> error("wrong ordering of ArgsGenerators, make sure at leat one (Semi)OrderedArgsGenerators comes before an ArbArgsGenerator.")
 					is ArgsGenerator<*> -> throwUnsupportedArgsGenerator(next)
 					else -> throwDontKnowHowToConvertToArgsGenerator(next)
 				}

--- a/src/test/kotlin/com/tegonal/minimalist/generators/AbstractArbArgsGeneratorTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/AbstractArbArgsGeneratorTest.kt
@@ -8,7 +8,6 @@ import ch.tutteli.kbox.a2
 import ch.tutteli.kbox.mapA3
 import com.tegonal.minimalist.config.arb
 import com.tegonal.minimalist.generators.impl.DefaultArbExtensionPoint
-import org.junit.jupiter.api.Test
 
 typealias ArbArgsTestFactoryResult<T> = ArgsTestFactoryResult<T, ArbArgsGenerator<T>>
 

--- a/src/test/kotlin/com/tegonal/minimalist/generators/AbstractOrderedArgsGeneratorTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/AbstractOrderedArgsGeneratorTest.kt
@@ -6,9 +6,7 @@ import ch.tutteli.atrium.api.verbs.expectGrouped
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.testfactories.TestFactory
 import com.tegonal.minimalist.config._components
-import com.tegonal.minimalist.config.arb
 import com.tegonal.minimalist.config.config
-import com.tegonal.minimalist.config.ordered
 import com.tegonal.minimalist.generators.impl.DefaultOrderedExtensionPoint
 import com.tegonal.minimalist.utils.createMinimalistRandom
 import kotlin.math.absoluteValue

--- a/src/test/kotlin/com/tegonal/minimalist/providers/ArgsArgumentProviderTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/providers/ArgsArgumentProviderTest.kt
@@ -4,9 +4,13 @@ import ch.tutteli.atrium.api.fluent.en_GB.toBeGreaterThanOrEqualTo
 import ch.tutteli.atrium.api.fluent.en_GB.toBeLessThanOrEqualTo
 import ch.tutteli.atrium.api.fluent.en_GB.toEqual
 import ch.tutteli.atrium.api.verbs.expect
+import ch.tutteli.kbox.Tuple
 import com.tegonal.minimalist.Args
 import com.tegonal.minimalist.component1
 import com.tegonal.minimalist.component2
+import com.tegonal.minimalist.generators.arb
+import com.tegonal.minimalist.generators.fromList
+import com.tegonal.minimalist.generators.ordered
 import com.tegonal.minimalist.testutils.Tuple4LikeStructure
 import org.junit.jupiter.params.ParameterizedTest
 
@@ -48,29 +52,97 @@ class ArgsArgumentProviderTest {
 		expect(value).toBeGreaterThanOrEqualTo(range.first).toBeLessThanOrEqualTo(range.last)
 	}
 
-
 	@ParameterizedTest
-	@ArgsSource("args")
-	fun args(index: Int, value: Long) {
-		val (expectedIndex, expectValue) = args()[index]
+	@ArgsSource("rawArgs")
+	fun rawArgsIsSplit(index: Int, value: Long) {
+		val (expectedIndex, expectValue) = rawArgs()[index]
 		expect(value).toEqual(expectValue)
 		expect(index).toEqual(expectedIndex)
 	}
 
 	@ParameterizedTest
-	@ArgsSource("pairs")
-	fun pairIsSplit(index: Int, value: Long) {
-		val (expectedIndex, expectValue) = pairs()[index]
+	@ArgsSource("orderedArgs")
+	fun orderedArgsIsSplit(index: Int, value: Long) {
+		val (expectedIndex, expectValue) = rawArgs()[index]
 		expect(value).toEqual(expectValue)
 		expect(index).toEqual(expectedIndex)
 	}
 
 	@ParameterizedTest
-	@ArgsSource("tupleLike")
-	fun tupleLikeIsNotSplit(tupleLike: Tuple4LikeStructure<Int, Long, Double, Float>) {
+	@ArgsSource("arbArgs")
+	fun arbArgsIsSplit(index: Int, value: Long) {
+		val (expectedIndex, expectValue) = rawArgs()[index]
+		expect(value).toEqual(expectValue)
+		expect(index).toEqual(expectedIndex)
+	}
+
+
+	@ParameterizedTest
+	@ArgsSource("rawPairs")
+	fun rawPairIsSplit(index: Int, value: Long) {
+		val (expectedIndex, expectValue) = rawPairs()[index]
+		expect(value).toEqual(expectValue)
+		expect(index).toEqual(expectedIndex)
+	}
+
+	@ParameterizedTest
+	@ArgsSource("orderedPairs")
+	fun orderedPairIsSplit(index: Int, value: Long) {
+		val (expectedIndex, expectValue) = rawPairs()[index]
+		expect(value).toEqual(expectValue)
+		expect(index).toEqual(expectedIndex)
+	}
+
+	@ParameterizedTest
+	@ArgsSource("arbPairs")
+	fun arbPairIsSplit(index: Int, value: Long) {
+		val (expectedIndex, expectValue) = rawPairs()[index]
+		expect(value).toEqual(expectValue)
+		expect(index).toEqual(expectedIndex)
+	}
+
+
+	@ParameterizedTest
+	@ArgsSource("rawTupleLike")
+	fun rawTupleLikeIsNotSplit(tupleLike: Tuple4LikeStructure<Int, Long, Double, Float>) {
 		// TODO would be nicer if we take the index from ParameterizedTest, could be possible with junit 5.4/6
-		val expectedTupleLike = tupleLike()[tupleLike.a1]
+		val expectedTupleLike = rawTupleLike()[tupleLike.a1]
 		expect(tupleLike).toEqual(expectedTupleLike)
+	}
+
+	@ParameterizedTest
+	@ArgsSource("orderedTupleLike")
+	fun orderedTupleLikeIsNotSplit(tupleLike: Tuple4LikeStructure<Int, Long, Double, Float>) {
+		// TODO would be nicer if we take the index from ParameterizedTest, could be possible with junit 5.4/6
+		val expectedTupleLike = rawTupleLike()[tupleLike.a1]
+		expect(tupleLike).toEqual(expectedTupleLike)
+	}
+
+	@ParameterizedTest
+	@ArgsSource("arbTupleLike")
+	fun arbTupleLikeIsNotSplit(tupleLike: Tuple4LikeStructure<Int, Long, Double, Float>) {
+		// TODO would be nicer if we take the index from ParameterizedTest, could be possible with junit 5.4/6
+		val expectedTupleLike = rawTupleLike()[tupleLike.a1]
+		expect(tupleLike).toEqual(expectedTupleLike)
+	}
+
+
+	@ParameterizedTest
+	@ArgsSource("rawNestedTuples")
+	fun rawNestedTuplesAreFlattenedAndSplit(i: Int, l: Long, d: Double) {
+		expect(i.toDouble() + l.toDouble()).toEqual(d)
+	}
+
+	@ParameterizedTest
+	@ArgsSource("orderedNestedTuples")
+	fun orderedNestedTuplesAreFlattenedAndSplit(i: Int, l: Long, d: Double) {
+		expect(i.toDouble() + l.toDouble()).toEqual(d)
+	}
+
+	@ParameterizedTest
+	@ArgsSource("arbNestedTuples")
+	fun arbNestedTuplesAreFlattenedAndSplit(i: Int, l: Long, d: Double) {
+		expect(i.toDouble() + l.toDouble()).toEqual(d)
 	}
 
 
@@ -91,13 +163,41 @@ class ArgsArgumentProviderTest {
 		fun rawValuesInRange() = (20L..22L)
 
 		@JvmStatic
-		fun args() = rawValuesInRange().mapIndexed { index, it -> Args.of(index, it) }
+		fun rawArgs() = rawValuesInRange().mapIndexed { index, it -> Args.of(index, it) }
 
 		@JvmStatic
-		fun pairs() = rawValuesInRange().mapIndexed { index, it -> index to it }
+		fun orderedArgs() = ordered.fromList(rawPairs())
 
 		@JvmStatic
-		fun tupleLike() = listOf(Tuple4LikeStructure(0, 2L, 3.0, 4.0f), Tuple4LikeStructure(1, 20L, 30.0, 40.0f))
+		fun arbArgs() = arb.fromList(rawPairs())
+
+
+		@JvmStatic
+		fun rawPairs() = rawValuesInRange().mapIndexed { index, it -> index to it }
+
+		@JvmStatic
+		fun orderedPairs() = ordered.fromList(rawArgs())
+
+		@JvmStatic
+		fun arbPairs() = arb.fromList(rawArgs())
+
+
+		@JvmStatic
+		fun rawTupleLike() = listOf(Tuple4LikeStructure(0, 2L, 3.0, 4.0f), Tuple4LikeStructure(1, 20L, 30.0, 40.0f))
+
+		@JvmStatic
+		fun orderedTupleLike() = ordered.fromList(rawTupleLike())
+
+		@JvmStatic
+		fun arbTupleLike() = arb.fromList(rawTupleLike())
+
+		@JvmStatic
+		fun rawNestedTuples() = listOf(Tuple(Tuple(1, 2L), 3.0), Tuple(Tuple(2, 1L), 3.0))
+
+		@JvmStatic
+		fun orderedNestedTuples() = ordered.fromList(rawNestedTuples())
+
+		@JvmStatic
+		fun arbNestedTuples() = arb.fromList(rawNestedTuples())
 	}
-
 }


### PR DESCRIPTION
because if one has to start nesting tuple due to the Tuple9 limit we still want them to be split into multiple arguments



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/minimalist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
