### PR TITLE
ArgsGeneratorSuffixDecider, allow to define custom AnnotationData

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,7 @@ jmh {
 	profilers = listOf("gc")
 	// run ./gradlew jmh -Pjmh.include=... to run a specific bench
 	// transform the txt to csv via ./scripts/jmh-txt-to-csv.sh
+	// find the report in build/results/jmh/results.txt.csv
 	includes.set(project.findProperty("jmh.include")?.let { listOf(it.toString()) } ?: emptyList())
 }
 

--- a/src/jmh/kotlin/com/tegonal/minimalist/ComponentLoadingBench.kt
+++ b/src/jmh/kotlin/com/tegonal/minimalist/ComponentLoadingBench.kt
@@ -1,0 +1,44 @@
+package com.tegonal.minimalist
+
+import com.tegonal.minimalist.config.ComponentFactoryContainer
+import com.tegonal.minimalist.config.build
+import com.tegonal.minimalist.config.create
+import com.tegonal.minimalist.config.impl.createSingletonVia
+import com.tegonal.minimalist.providers.ArgsRangeDecider
+import com.tegonal.minimalist.providers.impl.ProfileBasedArgsRangeDecider
+import com.tegonal.minimalist.utils.impl.loadService
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+@State(Scope.Benchmark)
+open class ComponentLoadingBench {
+
+	// 10x slower on my machine but the difference is 5'000 nanoseconds vs. ~50'000 nanoseconds.
+	// Not worth optimising for now
+	@Benchmark
+	fun viaLoadService() =
+		ComponentFactoryContainer.create(
+			mapOf(
+				ArgsRangeDecider::class createSingletonVia { _ ->
+					loadService<ArgsRangeDecider>(ProfileBasedArgsRangeDecider::class.qualifiedName!!)
+				},
+			),
+			emptyMap()
+		).build<ArgsRangeDecider>()
+
+	@Benchmark
+	fun hardCoded() =
+		ComponentFactoryContainer.create(
+			mapOf(
+				ArgsRangeDecider::class createSingletonVia { _ ->
+					ProfileBasedArgsRangeDecider()
+				},
+			),
+			emptyMap()
+		).build<ArgsRangeDecider>()
+}

--- a/src/main/kotlin/com/tegonal/minimalist/config/MinimalistConfig.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/config/MinimalistConfig.kt
@@ -1,11 +1,13 @@
 package com.tegonal.minimalist.config
 
-import com.tegonal.minimalist.utils.impl.checkIsNotBlank
-import com.tegonal.minimalist.utils.impl.failIfNegative
 import com.tegonal.minimalist.generators.ArgsGenerator
+import com.tegonal.minimalist.providers.ArgsGeneratorSuffixDecider
 import com.tegonal.minimalist.providers.ArgsRange
 import com.tegonal.minimalist.providers.ArgsRangeDecider
+import com.tegonal.minimalist.providers.impl.EmptyArgsGeneratorSuffixDecider
 import com.tegonal.minimalist.providers.impl.ProfileBasedArgsRangeDecider
+import com.tegonal.minimalist.utils.impl.checkIsNotBlank
+import com.tegonal.minimalist.utils.impl.failIfNegative
 import kotlin.random.Random
 
 /**
@@ -59,10 +61,19 @@ class MinimalistConfig(
 	val maxArgs: Int? = null,
 
 	/**
-	 * Defines which [ArgsRangeDecider] shall be used.
+	 * Defines which [ArgsRangeDecider] shall be used identified via fully qualified name.
+	 * Per default, the corresponding class is loaded via [java.util.ServiceLoader].
 	 */
 	val activeArgsRangeDecider: String = ProfileBasedArgsRangeDecider::class.qualifiedName ?: error(
 		"cannot determine qualified name of ProfileBasedArgsRangeDecider "
+	),
+
+	/**
+	 * Defines which [ArgsGeneratorSuffixDecider] shall be used identified via fully qualified name.
+	 * Per default, the corresponding class is loaded via [java.util.ServiceLoader].
+	 */
+	val activeArgsGeneratorSuffixDecider: String = EmptyArgsGeneratorSuffixDecider::class.qualifiedName ?: error(
+		"cannot determine qualified name of EmptyArgsGeneratorSuffixProvider "
 	),
 
 	/**
@@ -165,6 +176,7 @@ class MinimalistConfig(
 			maxArgs = maxArgs,
 			requestedMinArgs = requestedMinArgs,
 			activeArgsRangeDecider = activeArgsRangeDecider,
+			activeArgsGeneratorSuffixDecider = activeArgsGeneratorSuffixDecider,
 			activeEnv = activeEnv,
 			defaultProfile = defaultProfile,
 			testProfiles = testProfiles.toHashMap()
@@ -180,6 +192,7 @@ class MinimalistConfigBuilder(
 	var maxArgs: Int?,
 	var requestedMinArgs: Int?,
 	var activeArgsRangeDecider: String,
+	var activeArgsGeneratorSuffixDecider: String,
 	var activeEnv: String,
 	var defaultProfile: String,
 	var testProfiles: HashMap<String, HashMap<String, TestConfig>>
@@ -190,17 +203,10 @@ class MinimalistConfigBuilder(
 		requestedMinArgs = requestedMinArgs,
 		maxArgs = maxArgs,
 		activeArgsRangeDecider = activeArgsRangeDecider,
+		activeArgsGeneratorSuffixDecider = activeArgsGeneratorSuffixDecider,
 		activeEnv = activeEnv,
 		defaultProfile = defaultProfile,
 		testProfiles = TestProfiles.create(testProfiles)
 	)
 }
 
-/**
- * Our way to inject the [MinimalistConfig] into an instance after it was created via [java.util.ServiceLoader].
- *
- * @since 2.0.0
- */
-interface RequiresConfig {
-	var config: MinimalistConfig
-}

--- a/src/main/kotlin/com/tegonal/minimalist/config/impl/DefaultComponentFactoryContainer.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/config/impl/DefaultComponentFactoryContainer.kt
@@ -2,6 +2,7 @@ package com.tegonal.minimalist.config.impl
 
 import com.tegonal.minimalist.config.ComponentFactory
 import com.tegonal.minimalist.config.ComponentFactoryContainer
+import com.tegonal.minimalist.utils.impl.loadServices
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 import kotlin.reflect.cast
@@ -122,3 +123,15 @@ infix fun <T : Any> KClass<T>.createSingletonVia(factory: (ComponentFactoryConta
  */
 infix fun <T : Any> KClass<T>.createChainVia(factories: Sequence<(ComponentFactoryContainer) -> T>): Pair<KClass<*>, Sequence<ComponentFactory>> =
 	this to factories.map { ComponentFactory(it, producesSingleton = false) }
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 2.0.0
+ */
+inline fun <reified T : Any> createChainFromServiceLoaders() = T::class.createChainVia(
+	loadServices<T>().asSequence().map {
+		{ _ -> it }
+	}
+)

--- a/src/main/kotlin/com/tegonal/minimalist/config/impl/MinimalistPropertiesParser.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/config/impl/MinimalistPropertiesParser.kt
@@ -6,7 +6,7 @@ import com.tegonal.minimalist.config.TestConfig
 import com.tegonal.minimalist.utils.impl.FEATURE_REQUEST_URL
 import com.tegonal.minimalist.utils.impl.toIntOrErrorNotValid
 import com.tegonal.minimalist.utils.impl.toPositiveIntOrErrorNotValid
-import java.util.Properties
+import java.util.*
 
 /**
  * !! No backward compatibility guarantees !!
@@ -34,6 +34,7 @@ class MinimalistPropertiesParser {
 				isKey("maxArgs") -> maxArgs = value.toIntOrErrorNotValid(key)
 				isKey("requestedMinArgs") -> requestedMinArgs = value.toIntOrErrorNotValid(key)
 				isKey("activeArgsRangeDecider") -> activeArgsRangeDecider = value
+				isKey("activeArgsGeneratorSuffixDecider") -> activeArgsGeneratorSuffixDecider = value
 				isKey("activeEnv") -> activeEnv = value
 				isKey("defaultProfile") -> defaultProfile = value
 

--- a/src/main/kotlin/com/tegonal/minimalist/generators/ArbArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/ArbArgsGenerator.kt
@@ -1,8 +1,8 @@
 package com.tegonal.minimalist.generators
 
 import com.tegonal.minimalist.config.ComponentFactoryContainerProvider
-import com.tegonal.minimalist.generators.impl.DefaultArbExtensionPoint
 import com.tegonal.minimalist.config.MinimalistConfig
+import com.tegonal.minimalist.generators.impl.DefaultArbExtensionPoint
 import com.tegonal.minimalist.utils.createMinimalistRandom
 
 /**

--- a/src/main/kotlin/com/tegonal/minimalist/generators/orderedTransform.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/orderedTransform.kt
@@ -10,7 +10,6 @@ import com.tegonal.minimalist.config.config
 import com.tegonal.minimalist.config.ordered
 import com.tegonal.minimalist.generators.impl.OrderedArgsGeneratorTransformer
 
-
 /**
  * Maps the values `this` [OrderedArgsGenerator] generates to type [R] with the help of the given [transform] function.
  *

--- a/src/main/kotlin/com/tegonal/minimalist/providers/AnnotationData.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/AnnotationData.kt
@@ -9,6 +9,11 @@ import com.tegonal.minimalist.config.merge
 class AnnotationData(
 	val argsSourceMethodName: String,
 	val argsRangeOptions: ArgsRangeOptions = ArgsRangeOptions(),
+	/**
+	 * Generic map for extensions of Minimalist (or your own custom code), intended to be filled by an
+	 * [AnnotationDataDeducer] and later be consumed by e.g. [ArgsRangeDecider], [ArgsGeneratorSuffixDecider].
+	 */
+	val extensionData: Map<String, Any> = emptyMap()
 ) {
 	init {
 		check(argsSourceMethodName.isNotBlank()) {
@@ -29,7 +34,8 @@ fun AnnotationData.merge(other: AnnotationData): AnnotationData {
 	}
 	return AnnotationData(
 		argsSourceMethodName,
-		argsRangeOptions = this.argsRangeOptions.merge(other.argsRangeOptions)
+		argsRangeOptions = this.argsRangeOptions.merge(other.argsRangeOptions),
+		extensionData = this.extensionData + other.extensionData
 	)
 }
 

--- a/src/main/kotlin/com/tegonal/minimalist/providers/ArgsGeneratorSuffixDecider.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/ArgsGeneratorSuffixDecider.kt
@@ -1,0 +1,16 @@
+package com.tegonal.minimalist.providers
+
+import com.tegonal.minimalist.generators.ArgsGenerator
+
+/**
+ * Allows to define that a certain [ArgsGenerator] shall be combined as last.
+ *
+ * @since 2.0.0
+ */
+interface ArgsGeneratorSuffixDecider {
+
+	/**
+	 * Returns `null` in case no [ArgsGenerator] shall be combined last or a corresponding generator respectively.
+	 */
+	fun decide(annotationData: AnnotationData): ArgsGenerator<*>?
+}

--- a/src/main/kotlin/com/tegonal/minimalist/providers/impl/EmptyArgsGeneratorSuffixDecider.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/impl/EmptyArgsGeneratorSuffixDecider.kt
@@ -1,0 +1,15 @@
+package com.tegonal.minimalist.providers.impl
+
+import com.tegonal.minimalist.generators.ArgsGenerator
+import com.tegonal.minimalist.providers.AnnotationData
+import com.tegonal.minimalist.providers.ArgsGeneratorSuffixDecider
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 2.0.0
+ */
+class EmptyArgsGeneratorSuffixDecider : ArgsGeneratorSuffixDecider {
+	override fun decide(annotationData: AnnotationData): ArgsGenerator<*>? = null
+}

--- a/src/main/kotlin/com/tegonal/minimalist/providers/impl/ProfileBasedArgsRangeDecider.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/impl/ProfileBasedArgsRangeDecider.kt
@@ -6,7 +6,6 @@ import com.tegonal.minimalist.generators.ArgsGenerator
 import com.tegonal.minimalist.providers.ArgsRange
 import kotlin.math.absoluteValue
 
-
 /**
  * !! No backward compatibility guarantees !!
  * Reuse at your own risk

--- a/src/main/kotlin/com/tegonal/minimalist/utils/impl/serviceLoader.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/utils/impl/serviceLoader.kt
@@ -9,11 +9,18 @@ import java.util.*
  * @since 2.0.0
  */
 inline fun <reified T : Any> loadService(qualifiedName: String): T {
-	val klass = T::class
-	val allServices = ServiceLoader.load(klass.java)
+	val allServices = loadServices<T>()
 	return allServices.find { service ->
 		service::class.qualifiedName?.let { it == qualifiedName } ?: false
 	} ?: error(
-		"The specified ${klass.simpleName} $qualifiedName could not be found, make sure it is on the classpath and defined as Service (META-INF/services)"
+		"The specified ${T::class.simpleName} $qualifiedName could not be found, make sure it is on the classpath and defined as Service (META-INF/services)"
 	)
 }
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 2.0.0
+ */
+inline fun <reified T : Any> loadServices(): ServiceLoader<T> = ServiceLoader.load(T::class.java)

--- a/src/main/resources/META-INF/services/com.tegonal.minimalist.providers.AnnotationDataDeducer
+++ b/src/main/resources/META-INF/services/com.tegonal.minimalist.providers.AnnotationDataDeducer
@@ -1,0 +1,1 @@
+com.tegonal.minimalist.providers.impl.DefaultAnnotationDataDeducer

--- a/src/main/resources/META-INF/services/com.tegonal.minimalist.providers.ArgsGeneratorSuffixDecider
+++ b/src/main/resources/META-INF/services/com.tegonal.minimalist.providers.ArgsGeneratorSuffixDecider
@@ -1,0 +1,1 @@
+com.tegonal.minimalist.providers.impl.EmptyArgsGeneratorSuffixDecider


### PR DESCRIPTION
which means:
- AnnotationDataDeducer are a chain, load via ServiceLoader
- extend AnnotationData with a generic Map
- as a first use case, introduce ArgsGeneratorSuffixDecider which is able to add a generator to (possibly all -- depending on the implementation) ArgsSource



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/minimalist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
