### PR TITLE
make mergeWeighted an extension of arb

### DIFF
--- a/src/main/kotlin/com/tegonal/minimalist/generators/arbMerge.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/arbMerge.kt
@@ -24,7 +24,8 @@ import com.tegonal.minimalist.generators.impl.MultiArbArgsGeneratorIndexOfMerger
  *
  * @since 2.0.0
  */
-fun <T> mergeWeighted(
+@Suppress("UnusedReceiverParameter")
+fun <T> ArbExtensionPoint.mergeWeighted(
 	first: Pair<Int, ArbArgsGenerator<T>>,
 	second: Pair<Int, ArbArgsGenerator<T>>,
 	vararg others: Pair<Int, ArbArgsGenerator<T>>,

--- a/src/main/kotlin/com/tegonal/minimalist/generators/orderedConcatenate.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/orderedConcatenate.kt
@@ -34,7 +34,7 @@ private fun <T> concatAll(iterator: Iterator<OrderedArgsGenerator<T>>): OrderedA
 	var result = first
 	while (iterator.hasNext()) {
 		//TODO 2.1.0 would it be worth to introduce a Concatenator which takes n OrderedArgsGenerator instead of just 2?
-		result = result + iterator.next()
+		result += iterator.next()
 	}
 	return result
 }

--- a/src/main/kotlin/com/tegonal/minimalist/generators/semiOrderedCombine.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/semiOrderedCombine.kt
@@ -91,6 +91,6 @@ fun <A1, A2, R> SemiOrderedArgsGenerator<A1>.combine(
 fun <A1, A2, R> SemiOrderedArgsGenerator<A1>.combineDependent(
 	otherFactory: ArbExtensionPoint.(A1) -> ArbArgsGenerator<A2>,
 	transform: (A1, A2) -> R
-): SemiOrderedArgsGenerator<R> = this.mapIndexed { index, a1 ->
+): SemiOrderedArgsGenerator<R> = mapIndexed { index, a1 ->
 	transform(a1, this._components.arb.otherFactory(a1).generateOne(index))
 }

--- a/src/main/kotlin/com/tegonal/minimalist/generators/semiOrderedConcatenate.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/semiOrderedConcatenate.kt
@@ -34,7 +34,7 @@ private fun <T> concatAll(iterator: Iterator<SemiOrderedArgsGenerator<T>>): Semi
 	var result = first
 	while (iterator.hasNext()) {
 		//TODO 2.1.0 would it be worth to introduce a Concatenator which takes n SemiOrderedArgsGenerator instead of just 2?
-		result = result + iterator.next()
+		result += iterator.next()
 	}
 	return result
 }

--- a/src/test/kotlin/com/tegonal/minimalist/generators/ArbMergeWeightedTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/ArbMergeWeightedTest.kt
@@ -28,7 +28,7 @@ class ArbMergeWeightedTest {
 			weight to PseudoArbArgsGenerator((0..9).asSequence().map { it + (index + 1) * 10 })
 		}.toVararg()
 
-		val merged = mergeWeighted(weights.first() to g1, secondWithWeights, *othersWithWeights)
+		val merged = arb.mergeWeighted(weights.first() to g1, secondWithWeights, *othersWithWeights)
 
 		val l = merged.generate().take(100).toList()
 
@@ -52,18 +52,18 @@ class ArbMergeWeightedTest {
 		val g3 = arb.intFromUntil(40, 50)
 
 		expect {
-			mergeWeighted(weight to g1, 50 to g2)
+			arb.mergeWeighted(weight to g1, 50 to g2)
 		}.toThrow<IllegalStateException> {
 			messageToContain("$weight is not a valid (1.) weight, must be greater than 0")
 		}
 		expect {
-			mergeWeighted(50 to g1, weight to g2)
+			arb.mergeWeighted(50 to g1, weight to g2)
 		}.toThrow<IllegalStateException> {
 			messageToContain("$weight is not a valid (2.) weight, must be greater than 0")
 		}
 
 		expect {
-			mergeWeighted(10 to g1, 50 to g2, weight to g3)
+			arb.mergeWeighted(10 to g1, 50 to g2, weight to g3)
 		}.toThrow<IllegalStateException> {
 			messageToContain("$weight is not a valid (3.) weight, must be greater than 0")
 		}
@@ -76,7 +76,7 @@ class ArbMergeWeightedTest {
 		val g2 = arb.intFromUntil(20, 30)
 
 		expect {
-			mergeWeighted(weight1 to g1, weight2 to g2)
+			arb.mergeWeighted(weight1 to g1, weight2 to g2)
 		}.toThrow<ArithmeticException> {
 			messageToContain("integer overflow")
 		}
@@ -90,7 +90,7 @@ class ArbMergeWeightedTest {
 		val g3 = arb.intFromUntil(40, 50)
 
 		expect {
-			mergeWeighted(weight1 to g1, weight2 to g2, weight3 to g3)
+			arb.mergeWeighted(weight1 to g1, weight2 to g2, weight3 to g3)
 		}.toThrow<ArithmeticException> {
 			messageToContain("integer overflow")
 		}

--- a/src/test/kotlin/com/tegonal/minimalist/generators/ArbMergeWeightedThreeTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/ArbMergeWeightedThreeTest.kt
@@ -1,9 +1,6 @@
 package com.tegonal.minimalist.generators
 
 import ch.tutteli.kbox.Tuple
-import com.tegonal.minimalist.config._components
-import com.tegonal.minimalist.config.build
-import com.tegonal.minimalist.providers.ArgsRangeDecider
 import com.tegonal.minimalist.testutils.anyToList
 import com.tegonal.minimalist.testutils.getTestValue
 
@@ -17,7 +14,7 @@ class ArbMergeWeightedThreeTest : AbstractArbMergeTwoTest() {
 			val l = listOf(888_888, 999_999)
 			Tuple(
 				"$name1, $name2, fromList",
-				mergeWeighted(40 to g1, 50 to g2, 10 to modifiedArb.fromList(l)),
+				arb.mergeWeighted(40 to g1, 50 to g2, 10 to modifiedArb.fromList(l)),
 				anyToList(getTestValue(name1, 0)) + anyToList(getTestValue(name2, 1)) + l
 			)
 		}

--- a/src/test/kotlin/com/tegonal/minimalist/generators/ArbMergeWeightedTwoTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/ArbMergeWeightedTwoTest.kt
@@ -1,9 +1,6 @@
 package com.tegonal.minimalist.generators
 
 import ch.tutteli.kbox.Tuple
-import com.tegonal.minimalist.config._components
-import com.tegonal.minimalist.config.build
-import com.tegonal.minimalist.providers.ArgsRangeDecider
 import com.tegonal.minimalist.testutils.anyToList
 import com.tegonal.minimalist.testutils.getTestValue
 
@@ -16,7 +13,7 @@ class ArbMergeWeightedTwoTest : AbstractArbMergeTwoTest() {
 		val combined = g1Variants.combine(g2Variants) { (name1, g1), (name2, g2) ->
 			Tuple(
 				"$name1, $name2",
-				mergeWeighted(40 to g1, 60 to g2),
+				arb.mergeWeighted(40 to g1, 60 to g2),
 				anyToList(getTestValue(name1, 0)) + anyToList(getTestValue(name2, 1))
 			)
 		}


### PR DESCRIPTION
this way we always have two clear entry points, ordered and arb and not additionally helper functions such as mergeWeighted This also helps in finding the function via code completion.



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/minimalist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
