### PR TITLE
requestedMinArgs and SemiOrdered, ArgsRangeDecider uses AnnotationData

### DIFF
--- a/src/main/kotlin/com/tegonal/minimalist/config/MinimalistConfig.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/config/MinimalistConfig.kt
@@ -1,13 +1,15 @@
 package com.tegonal.minimalist.config
 
 import com.tegonal.minimalist.generators.ArgsGenerator
-import com.tegonal.minimalist.providers.SuffixArgsGeneratorDecider
+import com.tegonal.minimalist.generators.SemiOrderedArgsGenerator
 import com.tegonal.minimalist.providers.ArgsRange
 import com.tegonal.minimalist.providers.ArgsRangeDecider
-import com.tegonal.minimalist.providers.impl.SuffixArgsGeneratorNeverDecider
+import com.tegonal.minimalist.providers.SuffixArgsGeneratorDecider
 import com.tegonal.minimalist.providers.impl.ProfileBasedArgsRangeDecider
+import com.tegonal.minimalist.providers.impl.SuffixArgsGeneratorNeverDecider
 import com.tegonal.minimalist.utils.impl.checkIsNotBlank
 import com.tegonal.minimalist.utils.impl.failIfNegative
+import com.tegonal.minimalist.utils.seedToOffset
 import kotlin.random.Random
 
 /**
@@ -24,7 +26,7 @@ class MinimalistConfig(
 	 * Note, you are not allowed to fix a seed via minimalist.properties (which is usually committed), use
 	 * minimalist.local.properties instead (which is usually on the git ignore list).
 	 */
-	val seed: Int = Random.nextInt(),
+	val seed: Seed = Seed(Random.nextInt()),
 
 	/**
 	 * Influences an [ArgsRangeDecider]'s choice of [ArgsRange.offset], i.e. allows to skip certain test cases.
@@ -171,7 +173,7 @@ class MinimalistConfig(
 
 	fun copy(configure: MinimalistConfigBuilder.() -> Unit): MinimalistConfig =
 		MinimalistConfigBuilder(
-			seed = seed,
+			seed = seed.value,
 			offsetToDecidedOffset = offsetToDecidedOffset,
 			maxArgs = maxArgs,
 			requestedMinArgs = requestedMinArgs,
@@ -198,7 +200,7 @@ class MinimalistConfigBuilder(
 	var testProfiles: HashMap<String, HashMap<String, TestConfig>>
 ) {
 	fun build(): MinimalistConfig = MinimalistConfig(
-		seed = seed,
+		seed = Seed(seed),
 		offsetToDecidedOffset = offsetToDecidedOffset,
 		requestedMinArgs = requestedMinArgs,
 		maxArgs = maxArgs,
@@ -210,3 +212,16 @@ class MinimalistConfigBuilder(
 	)
 }
 
+/**
+ * Represents the Minimalist seed, typically used for [Random] and as offset in [SemiOrderedArgsGenerator.generate].
+ *
+ * Use [value] to retrieve the seed as such (e.g. for [Random]) and [toOffset] in case it shall be used as random offset
+ * @since 2.0.0
+ */
+@JvmInline
+value class Seed(val value: Int)
+
+/**
+ * @since 2.0.0
+ */
+fun Seed.toOffset() = seedToOffset(value)

--- a/src/main/kotlin/com/tegonal/minimalist/config/componentFactoryContainerExtensions.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/config/componentFactoryContainerExtensions.kt
@@ -63,7 +63,7 @@ val ComponentFactoryContainer.config: MinimalistConfig get() = build<MinimalistC
  * @since 2.0.0
  */
 fun ComponentFactoryContainer.createMinimalistRandom(seedOffset: Int): Random =
-	build<RandomFactory>().create(config.seed + seedOffset).also { random ->
+	build<RandomFactory>().create(config.seed.value + seedOffset).also { random ->
 		config.offsetToDecidedOffset?.also { repeat(it) { random.nextInt() } }
 	}
 

--- a/src/main/kotlin/com/tegonal/minimalist/generators/impl/generatorExtensionPoints.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/impl/generatorExtensionPoints.kt
@@ -28,9 +28,19 @@ class DefaultOrderedExtensionPoint(
  */
 class DefaultArbExtensionPoint(
 	override val componentFactoryContainer: ComponentFactoryContainer,
+	/**
+	 * Will be added to [com.tegonal.minimalist.config.MinimalistConfig.seed].
+	 *
+	 * Is allowed to be negative.
+	 */
 	override val seedBaseOffset: Int,
 ) : ArbExtensionPoint, ComponentFactoryContainerProvider {
 
-	override val arb: ArbExtensionPoint get() = DefaultArbExtensionPoint(componentFactoryContainer, seedBaseOffset + 1)
+	override val arb: ArbExtensionPoint
+		get() = DefaultArbExtensionPoint(
+			componentFactoryContainer,
+			// expected that this can overflow in the worst case
+			seedBaseOffset + 1
+		)
 	override val ordered: OrderedExtensionPoint get() = componentFactoryContainer.ordered
 }

--- a/src/main/kotlin/com/tegonal/minimalist/providers/ArgsRangeDecider.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/ArgsRangeDecider.kt
@@ -1,8 +1,7 @@
 package com.tegonal.minimalist.providers
 
-import com.tegonal.minimalist.config.ArgsRangeOptions
-import com.tegonal.minimalist.generators.ArgsGenerator
 import com.tegonal.minimalist.config.MinimalistConfig
+import com.tegonal.minimalist.generators.ArgsGenerator
 import com.tegonal.minimalist.utils.impl.checkIsPositive
 import com.tegonal.minimalist.utils.impl.failIfNegative
 
@@ -14,9 +13,9 @@ import com.tegonal.minimalist.utils.impl.failIfNegative
 interface ArgsRangeDecider {
 	/**
 	 * Returns an [ArgsRange] based on the given [argsGenerator] (and most likely the underlying [MinimalistConfig])
-	 * and [argsRangeOptions] if given.
+	 * and [annotationData] if given.
 	 */
-	fun decide(argsGenerator: ArgsGenerator<*>, argsRangeOptions: ArgsRangeOptions? = null): ArgsRange
+	fun decide(argsGenerator: ArgsGenerator<*>, annotationData: AnnotationData? = null): ArgsRange
 }
 
 

--- a/src/main/kotlin/com/tegonal/minimalist/providers/impl/BaseArgsRangeOptionsBasedArgsRangeDecider.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/impl/BaseArgsRangeOptionsBasedArgsRangeDecider.kt
@@ -5,11 +5,15 @@ import com.tegonal.minimalist.config.ArgsRangeOptions
 import com.tegonal.minimalist.config.MinimalistConfig
 import com.tegonal.minimalist.config._components
 import com.tegonal.minimalist.config.config
+import com.tegonal.minimalist.generators.ArbArgsGenerator
 import com.tegonal.minimalist.generators.ArgsGenerator
+import com.tegonal.minimalist.generators.OrderedArgsGenerator
 import com.tegonal.minimalist.generators.SemiOrderedArgsGenerator
+import com.tegonal.minimalist.generators.impl.throwUnsupportedArgsGenerator
+import com.tegonal.minimalist.providers.AnnotationData
 import com.tegonal.minimalist.providers.ArgsRange
 import com.tegonal.minimalist.providers.ArgsRangeDecider
-import kotlin.math.absoluteValue
+import com.tegonal.minimalist.utils.seedToOffset
 
 /**
  * Not really a good name, but hard to come up with a good one.
@@ -25,12 +29,12 @@ import kotlin.math.absoluteValue
  */
 abstract class BaseArgsRangeOptionsBasedArgsRangeDecider : ArgsRangeDecider {
 
-	final override fun decide(argsGenerator: ArgsGenerator<*>, argsRangeOptions: ArgsRangeOptions?): ArgsRange {
+	final override fun decide(argsGenerator: ArgsGenerator<*>, annotationData: AnnotationData?): ArgsRange {
 		val config = argsGenerator._components.config
-		val profile = argsRangeOptions?.profile ?: config.defaultProfile
+		val profile = annotationData?.argsRangeOptions?.profile ?: config.defaultProfile
 
 		return decideArgsRange(profile, config.activeEnv, argsGenerator)
-			.restrictBasedOnConfigAndArgsRangeOptions(config, argsRangeOptions, argsGenerator)
+			.restrictBasedOnConfigAndArgsRangeOptions(config, annotationData?.argsRangeOptions, argsGenerator)
 
 	}
 
@@ -52,32 +56,48 @@ abstract class BaseArgsRangeOptionsBasedArgsRangeDecider : ArgsRangeDecider {
 		argsGenerator: ArgsGenerator<*>
 	): ArgsRange =
 		run {
-			config.offsetToDecidedOffset?.let { this.copy(offset = (this.offset + it).absoluteValue) } ?: this
+			config.offsetToDecidedOffset
+				?.let { this.copy(offset = seedToOffset(this.offset + it)) }
+				?: this
 		}.let { argsRange ->
 			val maxArgs = config.maxArgs ?: argsRangeOptions?.maxArgs
 			val requestedMinArgs = config.requestedMinArgs ?: argsRangeOptions?.requestedMinArgs
-			val generatorSize = maybeGeneratorSize(argsGenerator)
+			val newTake = argsRange.take
+				.letIf(maxArgs != null) { take ->
+					minOf(maxArgs!!, take)
+				}.let { take ->
+					when (argsGenerator) {
+						is OrderedArgsGenerator -> {
+							// no need to take more as we would start to repeat values
+							// we can ignore requestedMinArgs for OrderedArgsGenerator
+							minOf(argsGenerator.size, take)
 
-			val newTake = argsRange.take.letIf(maxArgs != null) {
-				minOf(maxArgs!!, it)
-			}.letIf(requestedMinArgs != null) {
-				// it could be that requestedMinArgs > maxArgs in case requestedMinArgs was defined in config and
-				// maxArgs in argsRangeOptions. This is because config has precedence over argsRangeOptions.
-				maxOf(requestedMinArgs!!, it)
-			}.letIf(generatorSize != null) {
-				// no need to take more as we would start to repeat values, i.e. even if config defines requestedMinArgs
-				// we only take generatorSize if it is less than requestedMinArgs
-				// We don't use offset=0 in such cases because, who knows, maybe the tests are dependent somehow
-				// and we want to be sure we cover this via different offsets
-				minOf(generatorSize!!, it)
-			}
+							// Note, we don't use offset=0 in case generatorSize is less than `take` (i.e. which means we can
+							// run all combinations), because, who knows, maybe the tests are dependent somehow
+							// and we want to be sure we cover this via different offsets
+						}
+
+						is SemiOrderedArgsGenerator ->
+							minOf(argsGenerator.size, take).letIf(requestedMinArgs != null) { newTake ->
+								// in case one specified requestedMinArgs, then we take it into account, i.e. we
+								// start to repeat the fixed part of a SemiOrderedArgsGenerator
+								maxOf(requestedMinArgs!!, newTake)
+							}
+
+						is ArbArgsGenerator ->
+							take.letIf(requestedMinArgs != null) {
+								// it could be that requestedMinArgs > maxArgs in case requestedMinArgs was defined in
+								// config and maxArgs in argsRangeOptions.
+								// This is because config has precedence over argsRangeOptions.
+								maxOf(requestedMinArgs!!, take)
+							}
+
+						else -> throwUnsupportedArgsGenerator(argsGenerator)
+					}
+				}
 
 			argsRange.letIf(newTake != argsRange.take) {
 				argsRange.copy(take = newTake)
 			}
 		}
-
-	private fun maybeGeneratorSize(argsGenerator: ArgsGenerator<*>): Int? =
-		(argsGenerator as? SemiOrderedArgsGenerator<*>)?.size
-
 }

--- a/src/main/kotlin/com/tegonal/minimalist/providers/impl/DefaultArgsGeneratorToArgumentsConverter.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/impl/DefaultArgsGeneratorToArgumentsConverter.kt
@@ -71,6 +71,6 @@ class DefaultArgsGeneratorToArgumentsConverter : ArgsGeneratorToArgumentsConvert
 	): ArgsRange {
 		val componentFactoryContainer = argsGenerator._components
 		val argsRangeDecider = componentFactoryContainer.build<ArgsRangeDecider>()
-		return argsRangeDecider.decide(argsGenerator, annotationData.argsRangeOptions)
+		return argsRangeDecider.decide(argsGenerator, annotationData)
 	}
 }

--- a/src/main/kotlin/com/tegonal/minimalist/providers/impl/ProfileBasedArgsRangeDecider.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/impl/ProfileBasedArgsRangeDecider.kt
@@ -2,9 +2,9 @@ package com.tegonal.minimalist.providers.impl
 
 import com.tegonal.minimalist.config._components
 import com.tegonal.minimalist.config.config
+import com.tegonal.minimalist.config.toOffset
 import com.tegonal.minimalist.generators.ArgsGenerator
 import com.tegonal.minimalist.providers.ArgsRange
-import kotlin.math.absoluteValue
 
 /**
  * !! No backward compatibility guarantees !!
@@ -20,7 +20,7 @@ class ProfileBasedArgsRangeDecider() : BaseArgsRangeOptionsBasedArgsRangeDecider
 		argsGenerator: ArgsGenerator<*>
 	): ArgsRange = argsGenerator._components.config.let { config ->
 		ArgsRange(
-			offset = config.seed.absoluteValue,
+			offset = config.seed.toOffset(),
 			take = config.testProfiles.get(profileName, env).maxArgs
 		)
 	}

--- a/src/main/kotlin/com/tegonal/minimalist/utils/randomHelpers.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/utils/randomHelpers.kt
@@ -166,3 +166,8 @@ fun Random.nextBigInt(toExclusive: BigInt): BigInt {
 		}
 	}
 }
+
+/**
+ * Makes sure the given [seed] is positive, so that it can be used as offset.
+ */
+fun seedToOffset(seed: Int): Int = seed ushr 1

--- a/src/test/kotlin/com/tegonal/minimalist/generators/AbstractOrderedArgsGeneratorTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/AbstractOrderedArgsGeneratorTest.kt
@@ -6,9 +6,9 @@ import ch.tutteli.atrium.api.verbs.expectGrouped
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.testfactories.TestFactory
 import com.tegonal.minimalist.config.config
+import com.tegonal.minimalist.config.toOffset
 import com.tegonal.minimalist.generators.impl.DefaultOrderedExtensionPoint
 import com.tegonal.minimalist.utils.createMinimalistRandom
-import kotlin.math.absoluteValue
 
 typealias OrderedArgsTestFactoryResult<T> = ArgsTestFactoryResult<T, SemiOrderedArgsGenerator<T>>
 
@@ -94,8 +94,8 @@ abstract class AbstractOrderedArgsGeneratorTest<T>() : AbstractOrderedArgsGenera
 	fun generateOneIsTheSameAsGenerateFirst() =
 		generateOneIsTheSameAsGenerateFirstTest(
 			factory = { createGenerators() },
-			generateOne = { it.generateOne(customComponentFactoryContainer.config.seed.absoluteValue) },
-			generate = { it.generate(customComponentFactoryContainer.config.seed.absoluteValue) }
+			generateOne = { it.generateOne(customComponentFactoryContainer.config.seed.toOffset()) },
+			generate = { it.generate(customComponentFactoryContainer.config.seed.toOffset()) }
 		)
 
 	@TestFactory

--- a/src/test/kotlin/com/tegonal/minimalist/generators/ArbPseudoTransformationTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/ArbPseudoTransformationTest.kt
@@ -10,7 +10,7 @@ import com.tegonal.minimalist.testutils.PseudoArbArgsGenerator
 import com.tegonal.minimalist.utils.repeatForever
 import kotlin.test.Test
 
-class ArbPseudoTransformationTests {
+class ArbPseudoTransformationTest {
 
 	// Note, this test relies on implementation details and is thus fragile. E.g. it is undefined how two
 	// RandomArgsGenerator are combined, since the result is random the combination is random. We use

--- a/src/test/kotlin/com/tegonal/minimalist/generators/ArbTransformationTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/ArbTransformationTest.kt
@@ -2,7 +2,7 @@ package com.tegonal.minimalist.generators
 
 import ch.tutteli.kbox.Tuple
 
-class ArbTransformationTests : AbstractArbArgsGeneratorTest<Any>() {
+class ArbTransformationTest : AbstractArbArgsGeneratorTest<Any>() {
 
 	// see PseudoRandomArgsGeneratorTransformationTests for tests about combine
 
@@ -36,12 +36,12 @@ class ArbTransformationTests : AbstractArbArgsGeneratorTest<Any>() {
 					(1..4).flatMap { first -> (1..4).map { second -> setOf(first, second) } }
 				),
 				Tuple(
-					"transformMaterialised - flatMap",
+					"transform - flatMap",
 					generator.transform { s -> s.flatMap { sequenceOf(it, it + 10) } },
 					listOf(1, 11, 2, 12, 3, 13, 4, 14)
 				),
 				Tuple(
-					"transformMaterialised - zip",
+					"transform - zip",
 					generator.transform { s -> s.zip(s) { a1, a2 -> a1 + a2 } },
 					listOf(
 						/* 1+1 = */ 2,

--- a/src/test/kotlin/com/tegonal/minimalist/generators/OrderedAsSemiOrderedTransformationTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/OrderedAsSemiOrderedTransformationTest.kt
@@ -3,9 +3,9 @@ package com.tegonal.minimalist.generators
 import ch.tutteli.atrium.testfactories.TestFactory
 import ch.tutteli.kbox.Tuple
 
-class OrderedAsSemiOrderedTransformationTests : AbstractOrderedArgsGeneratorTest<Int>() {
+class OrderedAsSemiOrderedTransformationTest : AbstractOrderedArgsGeneratorTest<Int>() {
 
-	// see SemiOrderedArgsGeneratorCombinerTest for tests about combine
+	// see SemiOrderedCombineTest for tests about combine
 
 	override fun createGenerators() =
 		listOf(1, 2, 3, 4).let { l ->

--- a/src/test/kotlin/com/tegonal/minimalist/generators/OrderedTransformationTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/OrderedTransformationTest.kt
@@ -3,9 +3,9 @@ package com.tegonal.minimalist.generators
 import ch.tutteli.atrium.testfactories.TestFactory
 import ch.tutteli.kbox.Tuple
 
-class OrderedTransformationTests : AbstractOrderedArgsGeneratorTest<Int>() {
+class OrderedTransformationTest : AbstractOrderedArgsGeneratorTest<Int>() {
 
-	// see OrderedArgsGeneratorCombinerTest for tests about combine
+	// see OrderedCombineTest for tests about combine
 
 	override fun createGenerators() = listOf(1, 2, 3, 4).let { l ->
 		val mapFun: (Int) -> Int = { it + 1 }

--- a/src/test/kotlin/com/tegonal/minimalist/testutils/componentFactoryContainerExtensions.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/testutils/componentFactoryContainerExtensions.kt
@@ -1,12 +1,12 @@
 package com.tegonal.minimalist.testutils
 
 import ch.tutteli.kbox.Tuple3
-import com.tegonal.minimalist.config.ArgsRangeOptions
 import com.tegonal.minimalist.config.ComponentFactoryContainer
 import com.tegonal.minimalist.config.RandomFactory
 import com.tegonal.minimalist.config.create
 import com.tegonal.minimalist.config.impl.createSingletonVia
 import com.tegonal.minimalist.generators.ArgsGenerator
+import com.tegonal.minimalist.providers.AnnotationData
 import com.tegonal.minimalist.providers.ArgsRange
 import com.tegonal.minimalist.providers.ArgsRangeDecider
 
@@ -40,7 +40,7 @@ fun ComponentFactoryContainer.withMockedArgsRange(
 				object : ArgsRangeDecider {
 					override fun decide(
 						argsGenerator: ArgsGenerator<*>,
-						argsRangeOptions: ArgsRangeOptions?
+						annotationData: AnnotationData?
 					): ArgsRange = ArgsRange(offset = offset, take = take)
 				}
 			})


### PR DESCRIPTION
bugfix:
- don't use absoluteValue to convert a seed to offset as the absolute value of Int.MIN_VALUE is again Int.MIN_VALUE (as it overflows again)
  - use ushr 1 instead
  - introduce value class Seed + extension toOffset to make it a bit more obvious.



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/minimalist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
