### PR TITLE
remove step from intFrom... one shall use fromProgression instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,7 +654,7 @@ the nature of the generator generating arbitrary values. Following an example:
 ```kotlin
 // prefer a progression as follows ...
 arb.fromProgression(1..1000 step 2)
-// ... instead of filter (which is slower)
+// ... instead of filter (which is slower as every ~2nd time the number is even)
 arb.intFromTo(1, 1000).filter { it % 2 == 1 }
 ```
 

--- a/misc/tools/readme-examples/src/test/kotlin/readme/examples/CombinatorsExample.kt
+++ b/misc/tools/readme-examples/src/test/kotlin/readme/examples/CombinatorsExample.kt
@@ -105,7 +105,7 @@ class CombinatorsExample : PredefinedArgsProviders {
 	fun `code-dont-filter`() {
 		// prefer a progression as follows ...
 		arb.fromProgression(1..1000 step 2)
-		// ... instead of filter (which is slower)
+		// ... instead of filter (which is slower as every ~2nd time the number is even)
 		arb.intFromTo(1, 1000).filter { it % 2 == 1 }
 	}
 

--- a/misc/tools/readme-examples/src/test/kotlin/readme/examples/CombineTupleTest.kt
+++ b/misc/tools/readme-examples/src/test/kotlin/readme/examples/CombineTupleTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.params.ParameterizedTest
 //snippet-combine-tuple-import-end
 import org.junit.jupiter.api.Order
 
-@Suppress("unused")
+@Suppress("unused", "UNUSED_PARAMETER")
 @Order(1)
 //snippet-combine-tuple-start
 class CombineTupleTest : PredefinedArgsProviders {

--- a/src/main/kotlin/com/tegonal/minimalist/generators/arbNumber.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/arbNumber.kt
@@ -103,10 +103,8 @@ fun ArbExtensionPoint.intNegativeAndZero(): ArbArgsGenerator<Int> =
 fun ArbExtensionPoint.longNegativeAndZero(): ArbArgsGenerator<Long> =
 	longFromUntil(Long.MIN_VALUE, 1)
 
-
-
 /**
- * Returns an [ArbArgsGenerator] which generates [Int]s ranging [from] (inclusive) to [toExclusive].
+ * Returns an [ArbArgsGenerator] which generates [Int]s ranging [from] (inclusive) until [toExclusive].
  *
  * @since 2.0.0
  */
@@ -116,7 +114,7 @@ fun ArbExtensionPoint.intFromUntil(
 ): ArbArgsGenerator<Int> = IntFromUntilArbArgsGenerator(_components, seedBaseOffset, from, toExclusive)
 
 /**
- * Returns an [ArbArgsGenerator] which generates [Long]s ranging [from] (inclusive) to [toExclusive].
+ * Returns an [ArbArgsGenerator] which generates [Long]s ranging [from] (inclusive) until [toExclusive].
  *
  * @since 2.0.0
  */
@@ -126,7 +124,7 @@ fun ArbExtensionPoint.longFromUntil(
 ): ArbArgsGenerator<Long> = LongFromUntilArbArgsGenerator(_components, seedBaseOffset, from, toExclusive)
 
 /**
- * Returns an [ArbArgsGenerator] which generates [Double]s ranging [from] (inclusive) to [toExclusive].
+ * Returns an [ArbArgsGenerator] which generates [Double]s ranging [from] (inclusive) until [toExclusive].
  *
  * @since 2.0.0
  */
@@ -137,7 +135,7 @@ fun ArbExtensionPoint.doubleFromUntil(
 	DoubleFromUntilArbArgsGenerator(_components, seedBaseOffset, from, toExclusive)
 
 /**
- * Returns an [ArbArgsGenerator] which generates [BigInt]s ranging [from] (inclusive) to [toExclusive].
+ * Returns an [ArbArgsGenerator] which generates [BigInt]s ranging [from] (inclusive) until [toExclusive].
  *
  * @since 2.0.0
  */

--- a/src/main/kotlin/com/tegonal/minimalist/generators/orderedConcatenate.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/orderedConcatenate.kt
@@ -55,5 +55,7 @@ private fun <T> concatAll(iterator: Iterator<OrderedArgsGenerator<T>>): OrderedA
  */
 operator fun <T> OrderedArgsGenerator<T>.plus(
 	other: OrderedArgsGenerator<T>,
-): OrderedArgsGenerator<T> = OrderedArgsGeneratorConcatenator(this, other)
+): OrderedArgsGenerator<T> =
+	//TODO 2.1.0 bench when it makes sense to materialise instead of concatenation, for small sizes it could be faster
+	OrderedArgsGeneratorConcatenator(this, other)
 

--- a/src/main/kotlin/com/tegonal/minimalist/generators/orderedFromProgression.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/orderedFromProgression.kt
@@ -1,5 +1,9 @@
 package com.tegonal.minimalist.generators
 
+import com.tegonal.minimalist.config._components
+import com.tegonal.minimalist.generators.impl.IntFromToOrderedArgsGenerator
+import com.tegonal.minimalist.generators.impl.LongFromToOrderedArgsGenerator
+
 /**
  * Returns an [OrderedArgsGenerator] generating [Char]s based on the given [progression].
  *
@@ -7,8 +11,10 @@ package com.tegonal.minimalist.generators
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromProgression(progression: CharProgression): OrderedArgsGenerator<Char> =
-	if (progression.step > 0)
-		intFromTo(progression.first.code, progression.last.code, progression.step).map { it.toChar() }
+	if (progression.step > 0) {
+		IntFromToOrderedArgsGenerator(_components, progression.first.code, progression.last.code, progression.step)
+			.map { it.toChar() }
+	}
 	//TODO 2.1.0 no longer needed once we support minus steps in the iterator
 	else fromList(progression.toList())
 
@@ -19,7 +25,9 @@ fun OrderedExtensionPoint.fromProgression(progression: CharProgression): Ordered
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromProgression(progression: IntProgression): OrderedArgsGenerator<Int> =
-	if (progression.step > 0) intFromTo(progression.first, progression.last, progression.step)
+	if (progression.step > 0) {
+		IntFromToOrderedArgsGenerator(_components, progression.first, progression.last, progression.step)
+	}
 	//TODO 2.1.0 no longer needed once we support minus steps in the iterator
 	else fromList(progression.toList())
 
@@ -30,7 +38,8 @@ fun OrderedExtensionPoint.fromProgression(progression: IntProgression): OrderedA
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromProgression(progression: LongProgression): OrderedArgsGenerator<Long> =
-	if (progression.step > 0) longFromTo(progression.first, progression.last, progression.step)
+	if (progression.step > 0) {
+		LongFromToOrderedArgsGenerator(_components, progression.first, progression.last, progression.step)
+	}
 	//TODO 2.1.0 no longer needed once we support minus steps in the iterator
 	else fromList(progression.toList())
-

--- a/src/main/kotlin/com/tegonal/minimalist/generators/orderedNumber.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/orderedNumber.kt
@@ -5,75 +5,63 @@ import com.tegonal.minimalist.generators.impl.*
 import com.tegonal.minimalist.utils.BigInt
 
 /**
- * Returns an [OrderedArgsGenerator] which generates [Int]s ranging [from] (inclusive) to [toExclusive] using the given
- * [step].
+ * Returns an [OrderedArgsGenerator] which generates [Int]s ranging [from] (inclusive) until [toExclusive].
  *
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.intFromUntil(
 	from: Int,
 	toExclusive: Int,
-	step: Int = 1
-): OrderedArgsGenerator<Int> = IntFromUntilOrderedArgsGenerator(_components, from, toExclusive, step)
+): OrderedArgsGenerator<Int> = IntFromUntilOrderedArgsGenerator(_components, from, toExclusive, step = 1)
 
 /**
- * Returns an [OrderedArgsGenerator] which generates [Long]s ranging [from] (inclusive) to [toExclusive] using the
- * given [step].
+ * Returns an [OrderedArgsGenerator]which generates [Long]s ranging [from] (inclusive) until [toExclusive].
  *
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.longFromUntil(
 	from: Long,
 	toExclusive: Long,
-	step: Long = 1L
-): OrderedArgsGenerator<Long> = LongFromUntilOrderedArgsGenerator(_components, from, toExclusive, step)
+): OrderedArgsGenerator<Long> = LongFromUntilOrderedArgsGenerator(_components, from, toExclusive, step = 1)
 
 /**
- * Returns an [OrderedArgsGenerator] which generates [BigInt]s ranging [from] (inclusive) to [toExclusive] using the
- * given [step].
+ * Returns an [OrderedArgsGenerator] which generates [BigInt]s ranging [from] (inclusive) until [toExclusive].
  *
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.bigIntFromUntil(
 	from: BigInt,
 	toExclusive: BigInt,
-	step: BigInt = BigInt.ONE
-): OrderedArgsGenerator<BigInt> = BigIntFromUntilOrderedArgsGenerator(_components, from, toExclusive, step)
+): OrderedArgsGenerator<BigInt> = BigIntFromUntilOrderedArgsGenerator(_components, from, toExclusive, step = BigInt.ONE)
 
 
 /**
- * Returns an [OrderedArgsGenerator] which generates [Int]s ranging [from] (inclusive) to [toInclusive] using the given
- * [step].
+ * Returns an [OrderedArgsGenerator] which generates [Int]s ranging [from] (inclusive) to [toInclusive].
  *
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.intFromTo(
 	from: Int,
 	toInclusive: Int,
-	step: Int = 1
-): OrderedArgsGenerator<Int> = IntFromToOrderedArgsGenerator(_components, from, toInclusive, step)
+): OrderedArgsGenerator<Int> = IntFromToOrderedArgsGenerator(_components, from, toInclusive, step = 1)
 
 /**
- * Returns an [OrderedArgsGenerator] which generates [Long]s ranging [from] (inclusive) to [toInclusive] using the
- * given [step].
+ * Returns an [OrderedArgsGenerator] which generates [Long]s ranging [from] (inclusive) to [toInclusive].
  *
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.longFromTo(
 	from: Long,
 	toInclusive: Long,
-	step: Long = 1L
-): OrderedArgsGenerator<Long> = LongFromToOrderedArgsGenerator(_components, from, toInclusive, step)
+): OrderedArgsGenerator<Long> = LongFromToOrderedArgsGenerator(_components, from, toInclusive, step = 1L)
 
 /**
- * Returns an [OrderedArgsGenerator] which generates [BigInt]s ranging [from] (inclusive) to [toInclusive] using the
- * given [step].
+ * Returns an [OrderedArgsGenerator] which generates [BigInt]s ranging [from] (inclusive) to [toInclusive].
  *
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.bigIntFromTo(
 	from: BigInt,
 	toInclusive: BigInt,
-	step: BigInt = BigInt.ONE
 ): OrderedArgsGenerator<BigInt> =
-	BigIntFromUntilOrderedArgsGenerator(_components, from, toInclusive + BigInt.ONE, step)
+	BigIntFromUntilOrderedArgsGenerator(_components, from, toInclusive + BigInt.ONE, step = BigInt.ONE)

--- a/src/test/kotlin/com/tegonal/minimalist/generators/ArbNumberTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/ArbNumberTest.kt
@@ -1,9 +1,6 @@
 package com.tegonal.minimalist.generators
 
-import ch.tutteli.atrium.api.fluent.en_GB.toBeGreaterThan
-import ch.tutteli.atrium.api.fluent.en_GB.toBeGreaterThanOrEqualTo
-import ch.tutteli.atrium.api.fluent.en_GB.toBeLessThan
-import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.expect
 import ch.tutteli.kbox.Tuple
 import com.tegonal.minimalist.config._components
@@ -70,6 +67,48 @@ class ArbNumberTest : AbstractArbArgsGeneratorTest<Any>() {
 	fun longPositive() {
 		arb.longPositive().generateAndTakeBasedOnDecider().forEach {
 			expect(it).toBeGreaterThan(0)
+		}
+	}
+
+	@Test
+	fun intPositiveAndZero() {
+		arb.intPositiveAndZero().generateAndTakeBasedOnDecider().forEach {
+			expect(it).toBeGreaterThanOrEqualTo(0)
+		}
+	}
+
+	@Test
+	fun longPositiveAndZero() {
+		arb.longPositiveAndZero().generateAndTakeBasedOnDecider().forEach {
+			expect(it).toBeGreaterThanOrEqualTo(0)
+		}
+	}
+
+	@Test
+	fun intNegative() {
+		arb.intNegative().generateAndTakeBasedOnDecider().forEach {
+			expect(it).toBeLessThan(0)
+		}
+	}
+
+	@Test
+	fun longNegative() {
+		arb.longNegative().generateAndTakeBasedOnDecider().forEach {
+			expect(it).toBeLessThan(0)
+		}
+	}
+
+	@Test
+	fun intNegativeAndZero() {
+		arb.intNegativeAndZero().generateAndTakeBasedOnDecider().forEach {
+			expect(it).toBeLessThanOrEqualTo(0)
+		}
+	}
+
+	@Test
+	fun longNegativeAndZero() {
+		arb.longNegativeAndZero().generateAndTakeBasedOnDecider().forEach {
+			expect(it).toBeLessThanOrEqualTo(0)
 		}
 	}
 


### PR DESCRIPTION
only keep step in impl. I think fromProgression is more readable for cases where step > 1

moreover:
- don't produce null less likely for PredefinedBooleanProviders.arbBooleanOrNull
- use the word `until` instead of `to` if the upper bound is exclusive



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/minimalist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
