### PR TITLE
remove default arg from generateOne, doc seq/randomHelpers and bigInt

### DIFF
--- a/misc/tools/readme-examples/src/test/kotlin/readme/examples/CombineDependentTest.kt
+++ b/misc/tools/readme-examples/src/test/kotlin/readme/examples/CombineDependentTest.kt
@@ -14,14 +14,14 @@ import kotlin.test.assertTrue
 class CombineDependentTest : PredefinedArgsProviders {
 
 	@ParameterizedTest
-	@ArgsSource("moreThan10InSum")
+	@ArgsSource("arbMoreThan10InSum")
 	fun foo(a: Int, b: Int) {
 		assertTrue(a + b > 10)
 	}
 
 	companion object {
 		@JvmStatic
-		fun moreThan10InSum() = arb.intFromTo(1, 10).combineDependent { a ->
+		fun arbMoreThan10InSum() = arb.intFromTo(1, 10).combineDependent { a ->
 			arb.intFromTo(11 - a, 10)
 		}
 	}

--- a/misc/tools/readme-examples/src/test/kotlin/readme/examples/CombineManuallyTest.kt
+++ b/misc/tools/readme-examples/src/test/kotlin/readme/examples/CombineManuallyTest.kt
@@ -13,14 +13,14 @@ import org.junit.jupiter.api.Order
 class CombineManuallyTest : PredefinedArgsProviders {
 
 	@ParameterizedTest
-	@ArgsSource("numbersAndChar")
+	@ArgsSource("arbNumbersAndChar")
 	fun bar(i: Int, l: Long, d: Double, b: BigInt, c: Char) {
 		//...
 	}
 
 	companion object {
 		@JvmStatic
-		fun numbersAndChar() = run { // use run to let the compiler infer the return type
+		fun arbNumbersAndChar() = run { // use run to let the compiler infer the return type
 			val numbers = Tuple(
 				arb.int().zip(arb.long()), // combines them into an ArbArgsGenerators<Tuple2<Int, Long>>
 				arb.double(),

--- a/misc/tools/readme-examples/src/test/kotlin/readme/examples/CombineTupleTest.kt
+++ b/misc/tools/readme-examples/src/test/kotlin/readme/examples/CombineTupleTest.kt
@@ -14,14 +14,14 @@ import org.junit.jupiter.api.Order
 class CombineTupleTest : PredefinedArgsProviders {
 
 	@ParameterizedTest
-	@ArgsSource("ageAndName")
+	@ArgsSource("ageAndArbName")
 	fun foo(age: Int, name: String) {
 		//...
 	}
 
 	companion object {
 		@JvmStatic
-		fun ageAndName() = Tuple(
+		fun ageAndArbName() = Tuple(
 			ordered.intFromTo(15, 30),
 			arb.string(minLength = 3, maxLength = 50)
 		)

--- a/misc/tools/readme-examples/src/test/kotlin/readme/examples/DynamicTest.kt
+++ b/misc/tools/readme-examples/src/test/kotlin/readme/examples/DynamicTest.kt
@@ -1,0 +1,30 @@
+package readme.examples
+
+//snippet-dynamic-test-import-start
+import com.tegonal.minimalist.generators.arb
+import com.tegonal.minimalist.generators.generateAndTakeBasedOnDecider
+import com.tegonal.minimalist.generators.string
+import com.tegonal.minimalist.generators.zip
+import com.tegonal.minimalist.providers.PredefinedNumberProviders.Companion.arbIntPositive
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.TestFactory
+//snippet-dynamic-test-import-end
+
+import org.junit.jupiter.api.Order
+
+@Order(1)
+//snippet-dynamic-test-1-start
+class DynamicTest : PredefinedArgsProviders {
+
+	@TestFactory
+	fun arbExample() =
+		arbIntPositive().zip(arb.string(maxLength = 20))
+			.generateAndTakeBasedOnDecider()
+			.map { (positiveNumber, label) ->
+				dynamicTest("$positiveNumber $label") {
+					assertTrue(positiveNumber * -1 < 0)
+				}
+			}
+}
+//snippet-dynamic-test-1-end

--- a/misc/tools/readme-examples/src/test/kotlin/readme/examples/DynamicTestExample.kt
+++ b/misc/tools/readme-examples/src/test/kotlin/readme/examples/DynamicTestExample.kt
@@ -1,0 +1,48 @@
+package readme.examples
+
+import com.tegonal.minimalist.config.ArgsRangeOptions
+import com.tegonal.minimalist.generators.generateAndTakeBasedOnDecider
+import com.tegonal.minimalist.generators.intFromUntil
+import com.tegonal.minimalist.generators.ordered
+import com.tegonal.minimalist.providers.AnnotationData
+import com.tegonal.minimalist.providers.outsideParameterizedTest
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.Order
+import readme.examples.jupiter.ReadmeTest
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
+
+@Order(2)
+class DynamicTestExample : ReadmeTest {
+
+	@Test
+	fun `code-dynamic-test-1`() {
+		//snippet-dynamic-test-import-insert
+
+		//snippet-dynamic-test-1-insert
+	}
+
+	@Test
+	fun `code-dynamic-test-2`() {
+
+		//snippet-dynamic-test-2-insert
+	}
+
+	//snippet-dynamic-test-2-start
+	@TestFactory
+	fun orderedExample() =
+		ordered.intFromUntil(1, 100)
+			.generateAndTakeBasedOnDecider(
+				AnnotationData.outsideParameterizedTest(
+					argsRangeOptions = ArgsRangeOptions(profile = "Integration", maxArgs = 20)
+				)
+			)
+			.map { positiveNumber ->
+				dynamicTest("$positiveNumber") {
+					assertTrue(positiveNumber * -1 < 0)
+				}
+			}
+	//snippet-dynamic-test-2-end
+}

--- a/misc/tools/readme-examples/src/test/kotlin/readme/examples/FirstParameterizedTestExample.kt
+++ b/misc/tools/readme-examples/src/test/kotlin/readme/examples/FirstParameterizedTestExample.kt
@@ -10,8 +10,8 @@ class FirstParameterizedTestExample : ReadmeTest {
 
 	@Test
 	fun `code-first-1`() {
-		//snippet-first-1a-insert
+		//snippet-first-import-insert
 
-		//snippet-first-1b-insert
+		//snippet-first-insert
 	}
 }

--- a/misc/tools/readme-examples/src/test/kotlin/readme/examples/FirstTest.kt
+++ b/misc/tools/readme-examples/src/test/kotlin/readme/examples/FirstTest.kt
@@ -1,14 +1,14 @@
-//snippet-first-1a-start
+//snippet-first-import-start
 package readme.examples
 
 import com.tegonal.minimalist.providers.*
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.params.ParameterizedTest
-//snippet-first-1a-end
+//snippet-first-import-end
 import org.junit.jupiter.api.Order
 
 @Order(1)
-//snippet-first-1b-start
+//snippet-first-start
 class FirstTest : PredefinedArgsProviders {
 
 	@ParameterizedTest
@@ -22,4 +22,4 @@ class FirstTest : PredefinedArgsProviders {
 		fun myProvider() = 1..20
 	}
 }
-//snippet-first-1b-end
+//snippet-first-end

--- a/misc/tools/readme-examples/src/test/kotlin/readme/examples/RandomHelperExample.kt
+++ b/misc/tools/readme-examples/src/test/kotlin/readme/examples/RandomHelperExample.kt
@@ -1,0 +1,48 @@
+package readme.examples
+
+import com.tegonal.minimalist.generators.of
+import com.tegonal.minimalist.generators.ordered
+import com.tegonal.minimalist.generators.toArbArgsGenerator
+
+//snippet-random-helper-import-start
+import com.tegonal.minimalist.utils.createMinimalistRandom
+import com.tegonal.minimalist.utils.pickOneRandomly
+import com.tegonal.minimalist.utils.takeRandomly
+//snippet-random-helper-import-end
+
+import org.junit.jupiter.api.Test
+import readme.examples.jupiter.ReadmeTest
+
+@Suppress("UNUSED_VARIABLE", "unused")
+class RandomHelperExample : ReadmeTest {
+
+	@Test
+	fun `code-random-helper`() {
+		//snippet-random-helper-import-insert
+
+		// Imagine the list is more complicated than that, because if not, then better define it via arb or ordered
+		// since then it is most likely more efficient (would not allocate the memory for 1001 Ints)
+		val someList = (0..1000).toList()
+		val i1: Int = someList.pickOneRandomly()
+		val l1: List<Int> = someList.takeRandomly(10)
+
+		// Imagine a more complicated ordered which combines multiple generators and in the end maps to a model.
+		// In case you want to re-use it in another context than ParameterizedTests those helpers might come in handy
+		val complicatedSetup = ordered.of(1, 2, 3)
+		val i2: Int = complicatedSetup.pickOneRandomly()
+		val l2: List<Int> = complicatedSetup.takeRandomly(100)
+		// and of course, if you want to do more than that, then you can always turn your OrderedArgsGenerator
+		// into an ArbArgsGenerator and then work on Sequence:
+		val l3: Set<Int> = complicatedSetup.toArbArgsGenerator().generate()
+			.map { it + i1 + i2 }
+			//...
+			.take(50)
+			.toSet()
+
+		// creates a Random based on the configured seed, i.e. if you fix the seed, then you get a deterministic result
+		createMinimalistRandom().let { random ->
+			val i = random.nextInt()
+			//...
+		}
+	}
+}

--- a/misc/tools/readme-examples/src/test/kotlin/readme/examples/SequenceHelperExample.kt
+++ b/misc/tools/readme-examples/src/test/kotlin/readme/examples/SequenceHelperExample.kt
@@ -1,0 +1,30 @@
+package readme.examples
+
+//snippet-repeat-forever-import-start
+import com.tegonal.minimalist.utils.repeatForever
+//snippet-repeat-forever-import-end
+import org.junit.jupiter.api.Test
+import readme.examples.jupiter.ReadmeTest
+
+class SequenceHelperExample : ReadmeTest {
+
+	@Test
+	fun `code-repeat-forever`() {
+		//snippet-repeat-forever-import-insert
+
+		// creates a Sequence which yields the given constant forever
+		repeatForever(constant = 1)
+
+		// creates a Sequence which yields 1, 2, 3 forever
+		repeatForever(arrayOf(1, 2, 3), offset = 0)
+
+		// creates a Sequence which yields 2, 3, 1 forever
+		repeatForever(listOf(1, 2, 3), offset = 1)
+
+		// repeats Unit forever and can be used as a building block
+		repeatForever().flatMap { _ ->
+			// will repeat 11, 22, 33 forever
+			sequenceOf(1, 2, 3).mapIndexed { index, it -> it + (index + 1) * 10 }
+		}
+	}
+}

--- a/misc/tools/readme-examples/src/test/kotlin/readme/examples/jupiter/ReadmeState.kt
+++ b/misc/tools/readme-examples/src/test/kotlin/readme/examples/jupiter/ReadmeState.kt
@@ -4,9 +4,11 @@ package readme.examples.jupiter
  * copied from [Atrium](https://atriumlib.org).
  */
 object ReadmeState {
-    // not thread safe, if we should execute them in parallel then we would need to adjust this
-    val examples: MutableMap<String, String> = mutableMapOf()
-    val code: MutableSet<String> = HashSet()
-    val testClasses: MutableSet<Class<*>> = HashSet()
-    val snippets: MutableMap<String, String> = mutableMapOf()
+	// not thread safe, if we should execute them in parallel then we would need to adjust this
+	val examples: MutableMap<String, String> = mutableMapOf()
+	val code: MutableSet<String> = HashSet()
+	val testClasses: MutableSet<FullQualifiedName> = HashSet()
+	val snippets: MutableMap<String, String> = mutableMapOf()
 }
+
+typealias FullQualifiedName = String

--- a/misc/tools/readme-examples/src/test/kotlin/readme/examples/jupiter/WriteReadmeTest.kt
+++ b/misc/tools/readme-examples/src/test/kotlin/readme/examples/jupiter/WriteReadmeTest.kt
@@ -15,90 +15,90 @@ import kotlin.test.fail
  */
 class WriteReadmeTest {
 
-    @Test
-    fun updateReadme() {
-        check(ReadmeState.code.isNotEmpty()) {
-            "no code collected, did you run WriteReadmeTest without other tests?"
-        }
+	@Test
+	fun updateReadme() {
+		check(ReadmeState.code.isNotEmpty()) {
+			"no code collected, did you run WriteReadmeTest without other tests?"
+		}
 //        check(ReadmeState.examples.isNotEmpty()) {
 //            "no examples collected, did you run WriteReadmeTest without other tests?"
 //        }
 
-        val testContents = ReadmeState.testClasses
-            .asSequence()
-            .map { it.name.replace('.', '/') }
-            .map { qualifiedClass ->
-                qualifiedClass to fileContent("src/test/kotlin/$qualifiedClass.kt")
-            }
-            .toList()
-        testContents.forEach { (qualifiedClass, specContent) ->
-            extractSnippets(qualifiedClass, specContent)
-        }
+		val testContents = ReadmeState.testClasses
+			.asSequence()
+			.map { it.replace('.', '/') }
+			.map { qualifiedClass ->
+				qualifiedClass to fileContent("src/test/kotlin/$qualifiedClass.kt")
+			}
+			.toList()
+		testContents.forEach { (qualifiedClass, specContent) ->
+			extractSnippets(qualifiedClass, specContent)
+		}
 
-        check(ReadmeState.snippets.isNotEmpty()) {
-            "no snippets found, something is wrong"
-        }
-        var readmeContent = fileContent(README_PATH)
+		check(ReadmeState.snippets.isNotEmpty()) {
+			"no snippets found, something is wrong"
+		}
+		var readmeContent = fileContent(README_PATH)
 
-        ReadmeState.examples.forEach { (exampleId, output) ->
-            readmeContent = updateExampleLikeInReadme(readmeContent, testContents, exampleId, output)
-        }
-        ReadmeState.code.forEach { codeId ->
-            readmeContent = updateCodeInReadme(readmeContent, testContents, codeId)
-        }
-        ReadmeState.snippets.forEach { (snippetId, snippetContent) ->
-            readmeContent = updateSnippetInReadme(readmeContent, snippetId, snippetContent)
-        }
-        Paths.get(README_PATH).writeText(readmeContent)
-    }
-
-
-    private fun fileContent(path: String): String {
-        val file = Paths.get(path)
-        check(file.exists()) { "could not find ${file.absolutePathString()}" }
-        return file.readText()
-    }
+		ReadmeState.examples.forEach { (exampleId, output) ->
+			readmeContent = updateExampleLikeInReadme(readmeContent, testContents, exampleId, output)
+		}
+		ReadmeState.code.forEach { codeId ->
+			readmeContent = updateCodeInReadme(readmeContent, testContents, codeId)
+		}
+		ReadmeState.snippets.forEach { (snippetId, snippetContent) ->
+			readmeContent = updateSnippetInReadme(readmeContent, snippetId, snippetContent)
+		}
+		Paths.get(README_PATH).writeText(readmeContent)
+	}
 
 
-    private fun extractSnippets(qualifiedClass: String, specContent: String) {
-        Regex("//(snippet-.+)-start([\\S\\s]*?)//(snippet-.+)-end").findAll(specContent).forEach {
-            val (tag, content, endTag) = it.destructured
-            failIf(tag != endTag) { "tag $tag-start did not end with $tag-end but with $endTag" }
-            failIf(ReadmeState.snippets.containsKey(tag)) { "snippet $tag already defined, found a second time in $qualifiedClass" }
-            ReadmeState.snippets[tag] = content.trimIndent()
-        }
-    }
+	private fun fileContent(path: String): String {
+		val file = Paths.get(path)
+		check(file.exists()) { "could not find ${file.absolutePathString()}" }
+		return file.readText()
+	}
 
 
-    private fun updateExampleLikeInReadme(
+	private fun extractSnippets(qualifiedClass: String, specContent: String) {
+		Regex("//(snippet-.+)-start([\\S\\s]*?)//(snippet-.+)-end").findAll(specContent).forEach {
+			val (tag, content, endTag) = it.destructured
+			failIf(tag != endTag) { "tag $tag-start did not end with $tag-end but with $endTag" }
+			failIf(ReadmeState.snippets.containsKey(tag)) { "snippet $tag already defined, found a second time in $qualifiedClass" }
+			ReadmeState.snippets[tag] = content.trimIndent()
+		}
+	}
+
+
+	private fun updateExampleLikeInReadme(
 		readmeContent: String,
 		testContents: List<Pair<String, String>>,
 		exampleId: String,
 		exampleOutput: String,
-    ): String = when {
-        exampleId.startsWith("ex-") ->
-            updateExampleInReadme(readmeContent, testContents, exampleId, exampleOutput)
+	): String = when {
+		exampleId.startsWith("ex-") ->
+			updateExampleInReadme(readmeContent, testContents, exampleId, exampleOutput)
 
-        exampleId.startsWith("exs-") ->
-            updateSplitExampleInReadme(readmeContent, testContents, exampleId, exampleOutput)
+		exampleId.startsWith("exs-") ->
+			updateSplitExampleInReadme(readmeContent, testContents, exampleId, exampleOutput)
 
-        else -> {
-            fail("unknown example kind $exampleId")
-        }
-    }
+		else -> {
+			fail("unknown example kind $exampleId")
+		}
+	}
 
-    private fun updateExampleInReadme(
+	private fun updateExampleInReadme(
 		readmeContent: String,
 		testContents: List<Pair<String, String>>,
 		exampleId: String,
 		exampleOutput: String,
-    ): String = updateTagInReadme(
-        readmeContent,
-        testContents,
-        exampleId,
-        "example"
-    ) { qualifiedClass, lineNumber, sourceCode ->
-        """```kotlin
+	): String = updateTagInReadme(
+		readmeContent,
+		testContents,
+		exampleId,
+		"example"
+	) { qualifiedClass, lineNumber, sourceCode ->
+		"""```kotlin
         |$sourceCode
         |```
         |↑ <sub>[Example](https://github.com/robstoll/atrium/${System.getenv("README_SOURCETREE")}/misc/tools/readme-examples/src/test/kotlin/$qualifiedClass.kt#L$lineNumber)</sub> ↓ <sub>[Output](#$exampleId)</sub>
@@ -107,115 +107,115 @@ class WriteReadmeTest {
         |$exampleOutput
         |```
         """.trimMargin()
-    }
+	}
 
 
-    private fun updateSplitExampleInReadme(
+	private fun updateSplitExampleInReadme(
 		readmeContent: String,
 		testContents: List<Pair<String, String>>,
 		exampleId: String,
 		exampleOutput: String,
-    ): String {
-        val updatedReadme = updateTagInReadme(
-            readmeContent, testContents, exampleId, "ex-code"
-        ) { _, _, sourceCode ->
-            """```kotlin
+	): String {
+		val updatedReadme = updateTagInReadme(
+			readmeContent, testContents, exampleId, "ex-code"
+		) { _, _, sourceCode ->
+			"""```kotlin
             |$sourceCode
             |```""".trimMargin()
-        }
+		}
 
-        return updateTagInReadme(updatedReadme, "$exampleId-output", "exs-output") {
-            """```text
+		return updateTagInReadme(updatedReadme, "$exampleId-output", "exs-output") {
+			"""```text
             |$exampleOutput
             |```""".trimMargin()
-        }
-    }
+		}
+	}
 
-    private fun updateCodeInReadme(
+	private fun updateCodeInReadme(
 		readmeContent: String,
 		testContents: List<Pair<String, String>>,
 		snippetId: String,
-    ): String = updateTagInReadme(readmeContent, testContents, snippetId, "code") { _, _, sourceCode ->
+	): String = updateTagInReadme(readmeContent, testContents, snippetId, "code") { _, _, sourceCode ->
 
-        """```kotlin
+		"""```kotlin
         |$sourceCode
         |```
         """.trimMargin()
-    }
+	}
 
 
-    private fun updateTagInReadme(
+	private fun updateTagInReadme(
 		readmeContent: String,
 		testContents: List<Pair<String, String>>,
 		tag: String,
 		kind: String,
 		content: (String, Int, String) -> String
-    ): String = updateTagInReadme(readmeContent, tag, kind) {
-        val (qualifiedClass, lineNumber, sourceCode) = extractSourceCode(testContents, tag)
-        content(qualifiedClass, lineNumber, sourceCode)
-    }
+	): String = updateTagInReadme(readmeContent, tag, kind) {
+		val (qualifiedClass, lineNumber, sourceCode) = extractSourceCode(testContents, tag)
+		content(qualifiedClass, lineNumber, sourceCode)
+	}
 
-    private fun extractSourceCode(
+	private fun extractSourceCode(
 		testContents: List<Pair<String, String>>,
 		testId: String,
-    ): Triple<String, Int, String> {
-        var lineNumber: Int? = null
-        val sb = StringBuilder()
+	): Triple<String, Int, String> {
+		var lineNumber: Int? = null
+		val sb = StringBuilder()
 
-        testContents.forEach { (qualifiedClass, testContent) ->
-            testContent.lineSequence().forEachIndexed { index, line ->
-                if (lineNumber != null) {
-                    if (line.startsWith("\t}")) return Triple(
-                        qualifiedClass,
-                        lineNumber!!,
-                        sb.toString().trimIndent()
-                    )
-                    sb.append(line).append("\n")
+		testContents.forEach { (qualifiedClass, testContent) ->
+			testContent.lineSequence().forEachIndexed { index, line ->
+				if (lineNumber != null) {
+					if (line.startsWith("\t}")) return Triple(
+						qualifiedClass,
+						lineNumber!!,
+						sb.toString().trimIndent()
+					)
+					sb.append(line).append("\n")
 
-                } else if (line.trim().startsWith("fun `$testId`")) {
-                    lineNumber = index + 1
-                }
-            }
-        }
-        fail("cannot find source code for $testId")
-    }
+				} else if (line.trim().startsWith("fun `$testId`")) {
+					lineNumber = index + 1
+				}
+			}
+		}
+		fail("cannot find source code for $testId")
+	}
 
-    private fun updateTagInReadme(
-        readmeContent: String,
-        tag: String,
-        kind: String,
-        contentProvider: () -> String
-    ): String {
-        val tagRegex = Regex("( *)<$tag>[\\S\\s]*</$tag>")
-        return if (!tagRegex.containsMatchIn(readmeContent)) {
-            fail("$kind tag <$tag> not found in $README_PATH")
-        } else {
-            tagRegex.replace(readmeContent) {
-                """<$tag>
+	private fun updateTagInReadme(
+		readmeContent: String,
+		tag: String,
+		kind: String,
+		contentProvider: () -> String
+	): String {
+		val tagRegex = Regex("( *)<$tag>[\\S\\s]*</$tag>")
+		return if (!tagRegex.containsMatchIn(readmeContent)) {
+			fail("$kind tag <$tag> not found in $README_PATH")
+		} else {
+			tagRegex.replace(readmeContent) {
+				"""<$tag>
                 |
                 |${contentProvider()}
 				|
                 |</$tag>
                 """.trimMargin().prependIndent(it.destructured.component1())
-            }
-        }
-    }
+			}
+		}
+	}
 
-    private fun updateSnippetInReadme(
-        readmeContent: String,
-        snippetId: String,
-        snippetContent: String,
-    ): String {
+	private fun updateSnippetInReadme(
+		readmeContent: String,
+		snippetId: String,
+		snippetContent: String,
+	): String {
 
-        val snippet = Regex("//$snippetId-insert")
-        return if (!snippet.containsMatchIn(readmeContent)) {
-            fail("$snippetId is never inserted in $README_PATH")
-        } else {
-            snippet.replace(readmeContent) { snippetContent }
-        }
-    }
+		val snippet = Regex("//$snippetId-insert")
+		return if (!snippet.containsMatchIn(readmeContent)) {
+			fail("$snippetId is never inserted in $README_PATH")
+		} else {
+			snippet.replace(readmeContent) { snippetContent }
+		}
+	}
 
-    companion object {
-        private const val README_PATH = "../../../README.md"
-    }
+	companion object {
+		private const val README_PATH = "../../../README.md"
+	}
 }

--- a/src/main/kotlin/com/tegonal/minimalist/generators/SemiOrderedArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/SemiOrderedArgsGenerator.kt
@@ -22,7 +22,7 @@ interface SemiOrderedArgsGenerator<out T> : ArgsGenerator<T> {
 	 *
 	 * @since 2.0.0
 	 */
-	fun generateOne(offset: Int = 0): T = generate(offset).first()
+	fun generateOne(offset: Int): T = generate(offset).first()
 
 	/**
 	 * Returns an infinite stream of values starting at [offset] and repeating after reaching [size] of values
@@ -30,5 +30,5 @@ interface SemiOrderedArgsGenerator<out T> : ArgsGenerator<T> {
 	 *
 	 * @since 2.0.0
 	 */
-	fun generate(offset: Int = 0): Sequence<T>
+	fun generate(offset: Int): Sequence<T>
 }

--- a/src/main/kotlin/com/tegonal/minimalist/generators/argsGeneratorExtensions.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/argsGeneratorExtensions.kt
@@ -2,6 +2,7 @@ package com.tegonal.minimalist.generators
 
 import com.tegonal.minimalist.config._components
 import com.tegonal.minimalist.config.build
+import com.tegonal.minimalist.providers.AnnotationData
 import com.tegonal.minimalist.providers.ArgsRange
 import com.tegonal.minimalist.providers.ArgsRangeDecider
 
@@ -10,8 +11,8 @@ import com.tegonal.minimalist.providers.ArgsRangeDecider
  *
  * @since 2.0.0
  */
-fun <T> SemiOrderedArgsGenerator<T>.generateAndTakeBasedOnDecider(): Sequence<T> =
-	_components.build<ArgsRangeDecider>().decide(this).let(::generateAndTake)
+fun <T> SemiOrderedArgsGenerator<T>.generateAndTakeBasedOnDecider(annotationData: AnnotationData? = null): Sequence<T> =
+	_components.build<ArgsRangeDecider>().decide(this, annotationData).let(::generateAndTake)
 
 /**
  * Returns a finite sequence of values based on the given [argsRange].
@@ -27,8 +28,8 @@ fun <T> SemiOrderedArgsGenerator<T>.generateAndTake(argsRange: ArgsRange): Seque
  *
  * @since 2.0.0
  */
-fun <T> ArbArgsGenerator<T>.generateAndTakeBasedOnDecider(): Sequence<T> =
-	_components.build<ArgsRangeDecider>().decide(this).let { this.generateAndTake(it.take) }
+fun <T> ArbArgsGenerator<T>.generateAndTakeBasedOnDecider(annotationData: AnnotationData? = null): Sequence<T> =
+	_components.build<ArgsRangeDecider>().decide(this, annotationData).let { this.generateAndTake(it.take) }
 
 /**
  * Returns a finite sequence of values of size [take].

--- a/src/main/kotlin/com/tegonal/minimalist/generators/impl/ConstantArbArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/impl/ConstantArbArgsGenerator.kt
@@ -1,7 +1,7 @@
 package com.tegonal.minimalist.generators.impl
 
 import com.tegonal.minimalist.config.ComponentFactoryContainer
-import com.tegonal.minimalist.utils.impl.RepeatingConstantSequence
+import com.tegonal.minimalist.utils.repeatForever
 
 /**
  * !! No backward compatibility guarantees !!
@@ -14,7 +14,7 @@ class ConstantArbArgsGenerator<T>(
 	seedBaseOffset: Int,
 	private val constant: T,
 ) : BaseArbArgsGenerator<T>(componentFactoryContainer, seedBaseOffset) {
-	private val sequence = RepeatingConstantSequence(constant)
+	val sequence = repeatForever(constant)
 
 	override fun generateOne(seedOffset: Int): T = constant
 	override fun generate(seedOffset: Int): Sequence<T> = sequence

--- a/src/main/kotlin/com/tegonal/minimalist/generators/orderedCombineDependent.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/orderedCombineDependent.kt
@@ -45,7 +45,7 @@ fun <A1, A2, R> OrderedArgsGenerator<A1>.combineDependentMaterialised(
 ): OrderedArgsGenerator<R> = transformMaterialised { seq ->
 	seq.flatMap { a1 ->
 		val otherGenerator = this._components.ordered.otherFactory(a1)
-		otherGenerator.generate().take(otherGenerator.size).map { a2 ->
+		otherGenerator.generate(offset = 0).take(otherGenerator.size).map { a2 ->
 			transform(a1, a2)
 		}
 	}

--- a/src/main/kotlin/com/tegonal/minimalist/generators/orderedTo.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/orderedTo.kt
@@ -8,7 +8,7 @@ package com.tegonal.minimalist.generators
  * @since 2.0.0
  */
 fun <T> OrderedArgsGenerator<T>.toList(): List<T> =
-	generate().take(size).toList()
+	generate(offset = 0).take(size).toList()
 
 /**
  * Generates [size][OrderedArgsGenerator.size] values and puts them into a [Set].
@@ -18,5 +18,5 @@ fun <T> OrderedArgsGenerator<T>.toList(): List<T> =
  * @since 2.0.0
  */
 fun <T> OrderedArgsGenerator<T>.toSet(): Set<T> =
-	generate().take(size).toSet()
+	generate(offset = 0).take(size).toSet()
 

--- a/src/main/kotlin/com/tegonal/minimalist/generators/orderedTransform.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/orderedTransform.kt
@@ -122,4 +122,4 @@ fun <T> OrderedArgsGenerator<T>.filterNotMaterialised(predicate: (T) -> Boolean)
  */
 fun <T, R> OrderedArgsGenerator<T>.transformMaterialised(
 	transform: (Sequence<T>) -> Sequence<R>,
-): OrderedArgsGenerator<R> = generate().take(size).let(transform).toList().let(_components.ordered::fromList)
+): OrderedArgsGenerator<R> = generate(offset = 0).take(size).let(transform).toList().let(_components.ordered::fromList)

--- a/src/main/kotlin/com/tegonal/minimalist/providers/AnnotationData.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/AnnotationData.kt
@@ -8,7 +8,7 @@ import com.tegonal.minimalist.config.merge
  */
 class AnnotationData(
 	val argsSourceMethodName: String,
-	val argsRangeOptions: ArgsRangeOptions = ArgsRangeOptions(),
+	val argsRangeOptions: ArgsRangeOptions,
 	/**
 	 * Generic map for extensions of Minimalist (or your own custom code), intended to be filled by an
 	 * [AnnotationDataDeducer] and later be consumed by e.g. [ArgsRangeDecider], [SuffixArgsGeneratorDecider].
@@ -54,3 +54,12 @@ fun AnnotationData.Companion.fromOptions(
 		maxArgs = argsSourceOptions.maxArgs.takeIf { it > 0 },
 	),
 )
+
+/**
+ * @since 2.0.0
+ */
+fun AnnotationData.Companion.outsideParameterizedTest(
+	argsRangeOptions: ArgsRangeOptions,
+	extensionData: Map<String, Any> = emptyMap()
+): AnnotationData = AnnotationData("<not-specified>", argsRangeOptions, extensionData)
+

--- a/src/main/kotlin/com/tegonal/minimalist/providers/ArgsProvider.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/ArgsProvider.kt
@@ -1,6 +1,7 @@
 package com.tegonal.minimalist.providers
 
 import ch.tutteli.kbox.failIf
+import com.tegonal.minimalist.config.ArgsRangeOptions
 import com.tegonal.minimalist.config._components
 import com.tegonal.minimalist.config.build
 import com.tegonal.minimalist.config.buildChained
@@ -115,7 +116,9 @@ class ArgsProvider : ArgumentsProvider {
 		val genericArgsGeneratorCombiner = components.build<GenericArgsGeneratorCombiner>()
 		val argsGeneratorToArgumentsConverter = components.build<ArgsGeneratorToArgumentsConverter>()
 
-		val annotationData = annotationDataDeducers.fold(AnnotationData(argsSourceMethodName)) { data, deducer ->
+		val annotationData = annotationDataDeducers.fold(
+			AnnotationData(argsSourceMethodName, ArgsRangeOptions())
+		) { data, deducer ->
 			deducer.deduce(testMethod, argsSourceMethodName)?.let { data.merge(it) } ?: data
 		}
 

--- a/src/main/kotlin/com/tegonal/minimalist/providers/PredefinedBooleanProviders.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/PredefinedBooleanProviders.kt
@@ -8,20 +8,28 @@ import com.tegonal.minimalist.generators.*
 interface PredefinedBooleanProviders {
 	companion object {
 
+		/**
+		 * See [ordered.boolean()][OrderedExtensionPoint.boolean]
+		 */
 		@JvmStatic
 		fun boolean() = ordered.boolean()
 
+		/**
+		 * Returns an [OrderedArgsGenerator] which generates `false`, `true` or `null`.
+		 */
 		@JvmStatic
-		fun booleanAndNull() = ordered.boolean() + ordered.of(null)
+		fun booleanAndNull() = ordered.of(false, true, null)
 
+		/**
+		 * See [arb.boolean()][ArbExtensionPoint.boolean]
+		 */
 		@JvmStatic
 		fun arbBoolean() = arb.boolean()
 
+		/**
+		 * Returns an [ArbArgsGenerator] which generates `false`, `true` or `null`.
+		 */
 		@JvmStatic
-		fun arbBooleanOrNull() = arb.mergeWeighted(
-			// TODO 2.1.0 base on edge case config
-			95 to arb.boolean(),
-			5 to arb.of(null)
-		)
+		fun arbBooleanOrNull() = arb.of(false, true, null)
 	}
 }

--- a/src/main/kotlin/com/tegonal/minimalist/providers/PredefinedBoundProviders.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/PredefinedBoundProviders.kt
@@ -1,5 +1,7 @@
 package com.tegonal.minimalist.providers
 
+import ch.tutteli.kbox.Tuple2
+import com.tegonal.minimalist.generators.ArbArgsGenerator
 import com.tegonal.minimalist.generators.arb
 import com.tegonal.minimalist.generators.intBounds
 import com.tegonal.minimalist.generators.longBounds
@@ -9,9 +11,20 @@ import com.tegonal.minimalist.generators.longBounds
  */
 interface PredefinedBoundProviders {
 	companion object {
+
+		/**
+		 * Returns an [ArbArgsGenerator] which generates [Tuple2] representing a lower and upper bound where the bounds
+		 * range from [Int.MIN_VALUE] to [Int.MAX_VALUE] where their difference is at least 1 and thus results in a
+		 * minimal size of 2 if the upper bound is treated as inclusive.
+		 */
 		@JvmStatic
 		fun arbIntBoundsMinSize2() = arb.intBounds(minSize = 2)
 
+		/**
+		 * Returns an [ArbArgsGenerator] which generates [Tuple2] representing a lower and upper bound where the bounds
+		 * range from [Long.MIN_VALUE] to [Long.MAX_VALUE] where their difference is at least 1 and thus results in a
+		 * minimal size of 2 if the upper bound is treated as inclusive.
+		 */
 		@JvmStatic
 		fun arbLongBoundsMinSize2() = arb.longBounds(minSize = 2)
 	}

--- a/src/main/kotlin/com/tegonal/minimalist/providers/PredefinedCharProviders.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/PredefinedCharProviders.kt
@@ -1,5 +1,6 @@
 package com.tegonal.minimalist.providers
 
+import com.tegonal.minimalist.generators.ArbExtensionPoint
 import com.tegonal.minimalist.generators.arb
 import com.tegonal.minimalist.generators.char
 
@@ -8,6 +9,9 @@ import com.tegonal.minimalist.generators.char
  */
 interface PredefinedCharProviders {
 	companion object {
+		/**
+		 * See [arb.char()][ArbExtensionPoint.char]
+		 */
 		@JvmStatic
 		fun arbChar() = arb.char()
 	}

--- a/src/main/kotlin/com/tegonal/minimalist/providers/PredefinedNumberProviders.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/providers/PredefinedNumberProviders.kt
@@ -7,36 +7,70 @@ import com.tegonal.minimalist.generators.*
  */
 interface PredefinedNumberProviders {
 	companion object {
+		/**
+		 * See [arb.int()][ArbExtensionPoint.int]
+		 */
 		@JvmStatic
 		fun arbInt() = arb.int()
 
+		/**
+		 * See [arb.long()][ArbExtensionPoint.long]
+		 */
 		@JvmStatic
 		fun arbLong() = arb.long()
 
+		/**
+		 * See [arb.double()][ArbExtensionPoint.double]
+		 */
 		@JvmStatic
 		fun arbDouble() = arb.double()
 
+		/**
+		 * See [arb.intPositive()][ArbExtensionPoint.intPositive]
+		 */
 		@JvmStatic
 		fun arbIntPositive() = arb.intPositive()
 
+
+		/**
+		 * See [arb.longPositive()][ArbExtensionPoint.longPositive]
+		 */
 		@JvmStatic
 		fun arbLongPositive() = arb.longPositive()
 
+		/**
+		 * See [arb.intPositiveAndZero()][ArbExtensionPoint.intPositiveAndZero]
+		 */
 		@JvmStatic
 		fun arbIntPositiveAndZero() = arb.intPositiveAndZero()
 
+		/**
+		 * See [arb.longPositiveAndZero()][ArbExtensionPoint.longPositiveAndZero]
+		 */
 		@JvmStatic
 		fun arbLongPositiveAndZero() = arb.longPositiveAndZero()
 
+		/**
+		 * See [arb.intNegative()][ArbExtensionPoint.intNegative]
+		 */
 		@JvmStatic
 		fun arbIntNegative() = arb.intNegative()
 
+		/**
+		 * See [arb.longNegative()][ArbExtensionPoint.longNegative]
+		 */
 		@JvmStatic
 		fun arbLongNegative() = arb.longNegative()
 
+		/**
+		 * See [arb.intNegativeAndZero()][ArbExtensionPoint.intNegativeAndZero]
+		 */
 		@JvmStatic
 		fun arbIntNegativeAndZero() = arb.intNegativeAndZero()
 
+		/**
+		 * See [arb.longNegativeAndZero()][ArbExtensionPoint.longNegativeAndZero]
+		 */
 		@JvmStatic
 		fun arbLongNegativeAndZero() = arb.longNegativeAndZero()
 	}

--- a/src/main/kotlin/com/tegonal/minimalist/utils/bigInt.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/utils/bigInt.kt
@@ -1,0 +1,78 @@
+package com.tegonal.minimalist.utils
+
+import com.tegonal.minimalist.utils.impl.checkIsPositive
+import com.tegonal.minimalist.utils.impl.requireFromLessThanToExclusive
+import java.math.BigInteger
+import kotlin.random.Random
+import kotlin.random.asJavaRandom
+
+/**
+ * @since 2.0.0
+ */
+typealias BigInt = BigInteger
+
+/**
+ * Converts `this` [Int] to a [BigInt].
+ * @since 2.0.0
+ */
+@Suppress("NOTHING_TO_INLINE")
+inline fun Int.toBigInt() = this.toBigInteger()
+
+/**
+ * Converts `this` [Long] to a [BigInt].
+ * @since 2.0.0
+ */
+@Suppress("NOTHING_TO_INLINE")
+inline fun Long.toBigInt() = this.toBigInteger()
+
+/**
+ * Generates a random [BigInt] uniformly distributed between [from] (inclusive) and the specified [toExclusive] bound.
+ *
+ * @param from defines the lower bound (inclusive), must be less than [toExclusive].
+ * @param toExclusive defines the exclusive upper bound.
+ *
+ * @throws IllegalArgumentException if [from] is not less than [toExclusive]
+ *
+ * @since 2.0.0
+ */
+fun Random.nextBigInt(from: BigInt, toExclusive: BigInt): BigInt {
+	requireFromLessThanToExclusive(from, toExclusive)
+	val range = toExclusive - from
+	val result = nextBigInt(range)
+	return result + from
+}
+
+/**
+ * Generates a random [BigInt] uniformly distributed between `0` (inclusive) and the specified [toExclusive] bound.
+ *
+ * @param toExclusive defines the exclusive upper bound and must be positive.
+ *
+ * @throws IllegalStateException if [toExclusive] is negative or zero.
+ *
+ * @since 2.0.0
+ */
+fun Random.nextBigInt(toExclusive: BigInt): BigInt {
+	checkIsPositive(toExclusive, "toExclusive")
+	val bitLength = toExclusive.bitLength()
+	when {
+		bitLength <= 31 -> return nextInt(toExclusive.toInt()).toBigInt()
+		bitLength <= 63 -> return nextLong(toExclusive.toLong()).toBigInt()
+		else -> {
+			val javaRandom = this.asJavaRandom()
+			var count = 0
+			val maxTries = 50
+			while (true) {
+				val candidate = BigInteger(bitLength, javaRandom)
+				// rejection sampling: as we generate 0..2^bitLength - 1 which might be greater than or equal to
+				// toExclusive, we only accept a candidate which fits into the requested range and retry otherwise.
+				// Chances to pick a wrong candidate is in the worst case (toExclusive = 2^x+1) at nearly 50%, i.e.
+				// we should quickly get a candidate in most cases. To prevent that we run into a bug in case of a buggy
+				// random we stop after 50 tries (in theory, 50 times a wrong candidate in a row could happen even for
+				// a non-buggy random but the chances are (1/2)^50, so very unlikely and a buggy random more likely).
+				if (candidate < toExclusive) return candidate
+				else if (count >= maxTries) error("looks like we deal with a non uniform-random ($this), could not find a candidate after $count tries -- are you mocking Random? If so, adjust your mocking logic, if not, then try to re-run your test and report the buggy random in case this error re-appears")
+				else ++count
+			}
+		}
+	}
+}

--- a/src/main/kotlin/com/tegonal/minimalist/utils/randomHelpers.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/utils/randomHelpers.kt
@@ -3,14 +3,12 @@ package com.tegonal.minimalist.utils
 import com.tegonal.minimalist.config.MinimalistConfig
 import com.tegonal.minimalist.config._components
 import com.tegonal.minimalist.config.createMinimalistRandom
+import com.tegonal.minimalist.config.ordered
 import com.tegonal.minimalist.generators.SemiOrderedArgsGenerator
 import com.tegonal.minimalist.generators.ordered
-import com.tegonal.minimalist.utils.impl.checkIsPositive
-import com.tegonal.minimalist.utils.impl.requireFromLessThanToExclusive
-import java.math.BigInteger
+import com.tegonal.minimalist.generators.toArbArgsGenerator
 import kotlin.random.Random
-import kotlin.random.asJavaRandom
-
+import com.tegonal.minimalist.generators.ArbArgsGenerator
 /**
  * Picks randomly one element from `this` [Collection] based on the configured [MinimalistConfig.seed]
  * @since 2.0.0
@@ -50,12 +48,22 @@ fun <T> Array<T>.pickOneRandomly(): T =
 
 /**
  * Picks randomly one element from `this` [SemiOrderedArgsGenerator] based on the configured [MinimalistConfig.seed].
+ *
  * @since 2.0.0
  */
 fun <T> SemiOrderedArgsGenerator<T>.pickOneRandomly(seedOffset: Int = 0): T =
 	_components.createMinimalistRandom(seedOffset).nextInt(0, size).let { offset ->
 		generateOne(offset)
 	}
+
+/**
+ * Takes randomly the given [amount] of elements from `this` [SemiOrderedArgsGenerator].
+ *
+ * @since 2.0.0
+ */
+fun <T> SemiOrderedArgsGenerator<T>.takeRandomly(amount: Int, seedOffset: Int = 0): List<T> =
+	toArbArgsGenerator().generate(seedOffset).take(amount).toList()
+
 
 /**
  * Takes the given [amount] of elements from `this` [Iterable] (likewise [Iterable.take]) but in a random way
@@ -111,61 +119,6 @@ fun <T> Sequence<T>.takeRandomly(amount: Int): Sequence<T> {
  */
 fun createMinimalistRandom(): Random = ordered._components.createMinimalistRandom(seedOffset = 0)
 
-/**
- * @since 2.0.0
- */
-typealias BigInt = BigInteger
-
-/**
- * @since 2.0.0
- */
-@Suppress("NOTHING_TO_INLINE")
-inline fun Int.toBigInt() = this.toBigInteger()
-
-/**
- * @since 2.0.0
- */
-@Suppress("NOTHING_TO_INLINE")
-inline fun Long.toBigInt() = this.toBigInteger()
-
-/**
- * @since 2.0.0
- */
-fun Random.nextBigInt(from: BigInt, toExclusive: BigInt): BigInt {
-	requireFromLessThanToExclusive(from, toExclusive)
-	val range = toExclusive - from
-	val result = nextBigInt(range)
-	return result + from
-}
-
-/**
- * @since 2.0.0
- */
-fun Random.nextBigInt(toExclusive: BigInt): BigInt {
-	checkIsPositive(toExclusive, "toExclusive")
-	val bitLength = toExclusive.bitLength()
-	when {
-		bitLength <= 31 -> return nextInt(toExclusive.toInt()).toBigInt()
-		bitLength <= 63 -> return nextLong(toExclusive.toLong()).toBigInt()
-		else -> {
-			val javaRandom = this.asJavaRandom()
-			var count = 0
-			val maxTries = 50
-			while (true) {
-				val candidate = BigInteger(bitLength, javaRandom)
-				// rejection sampling: as we generate 0..2^bitLength - 1 which might be greater than or equal to
-				// toExclusive, we only accept a candidate which fits into the requested range and retry otherwise.
-				// Chances to pick a wrong candidate is in the worst case (toExclusive = 2^x+1) at nearly 50%, i.e.
-				// we should quickly get a candidate in most cases. To prevent that we run into a bug in case of a buggy
-				// random we stop after 50 tries (in theory, 50 times a wrong candidate in a row could happen even for
-				// a non-buggy random but the chances are (1/2)^50, so very unlikely and a buggy random more likely).
-				if (candidate < toExclusive) return candidate
-				else if (count >= maxTries) error("looks like we deal with a non uniform-random ($this), could not find a candidate after $count tries -- are you mocking Random? If so, adjust your mocking logic, if not, then try to re-run your test and report the buggy random in case this error re-appears")
-				else ++count
-			}
-		}
-	}
-}
 
 /**
  * Makes sure the given [seed] is positive, so that it can be used as offset.

--- a/src/main/kotlin/com/tegonal/minimalist/utils/sequenceHelpers.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/utils/sequenceHelpers.kt
@@ -2,6 +2,7 @@ package com.tegonal.minimalist.utils
 
 import com.tegonal.minimalist.utils.impl.ForeverUnitSequence
 import com.tegonal.minimalist.utils.impl.RepeatingArraySequence
+import com.tegonal.minimalist.utils.impl.RepeatingConstantSequence
 import com.tegonal.minimalist.utils.impl.RepeatingListSequence
 
 /**
@@ -21,3 +22,9 @@ fun <T> repeatForever(list: List<T>, offset: Int = 0): Sequence<T> = RepeatingLi
  * @since 2.0.0
  */
 fun <T> repeatForever(array: Array<T>, offset: Int = 0): Sequence<T> = RepeatingArraySequence(array, offset)
+
+/**
+ * Returns an infinite [Sequence] backed by the given [constant].
+ * @since 2.0.0
+ */
+fun <T> repeatForever(constant: T): Sequence<T> = RepeatingConstantSequence(constant)

--- a/src/test/kotlin/com/tegonal/minimalist/generators/AbstractOrderedArgsGeneratorTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/AbstractOrderedArgsGeneratorTest.kt
@@ -17,7 +17,7 @@ abstract class AbstractOrderedArgsGeneratorWithoutAnnotationsTest : AbstractArgs
 	val modifiedOrdered: OrderedExtensionPoint = DefaultOrderedExtensionPoint(customComponentFactoryContainer)
 
 	protected fun <T> canAlwaysTakeTheDesiredAmountTest(factory: () -> OrderedArgsTestFactoryResult<T>) =
-		super.canAlwaysTakeTheDesiredAmountTest(factory) { it.generate() }
+		super.canAlwaysTakeTheDesiredAmountTest(factory) { it.generate(offset = 0) }
 
 	protected fun <T> coversAllCasesTest(factory: () -> OrderedArgsTestFactoryResult<T>) =
 		testFactory(factory) { generator, expectedValues, _ ->
@@ -26,7 +26,7 @@ abstract class AbstractOrderedArgsGeneratorWithoutAnnotationsTest : AbstractArgs
 
 				(1..expectedValues.size).forEach { take ->
 					group("take $take") {
-						val l = generator.generate().take(take).toList()
+						val l = generator.generate(offset = 0).take(take).toList()
 						@Suppress("UNCHECKED_CAST")
 						(expect(l) as Expect<List<*>>).toContainExactlyElementsOf(expectedValues.take(take))
 					}
@@ -49,7 +49,7 @@ abstract class AbstractOrderedArgsGeneratorWithoutAnnotationsTest : AbstractArgs
 	) = testFactory(factory) { generator, _, _ ->
 		val generatorSize = generator.size
 		val doubleSize = generatorSize * 2
-		val list = generator.generate().take(doubleSize).toList()
+		val list = generator.generate(offset = 0).take(doubleSize).toList()
 		expect(list) {
 			size.toEqual(doubleSize)
 			feature("toSet", { toSet() }) {
@@ -65,7 +65,7 @@ abstract class AbstractOrderedArgsGeneratorWithoutAnnotationsTest : AbstractArgs
 		factory: () -> OrderedArgsTestFactoryResult<T>
 	) = testFactory(factory) { generator, expectedValues, _ ->
 		val take = expectedValues.size
-		val list = generator.generate().take(take).toList()
+		val list = generator.generate(offset = 0).take(take).toList()
 		expectGrouped {
 			(1 until take).forEach { offset ->
 				generator.generate(offset).take(take).forEachIndexed { index, value ->

--- a/src/test/kotlin/com/tegonal/minimalist/generators/AbstractOrderedCombinerTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/AbstractOrderedCombinerTest.kt
@@ -51,20 +51,20 @@ abstract class AbstractOrderedCombinerTest : BaseTest() {
 	companion object {
 
 		@JvmStatic
-		fun numOfIntAndChars() = Tuple(
+		fun arbNumOfIntAndChars() = Tuple(
 			arb.intFromUntil(1, 15),
 			arb.intFromUntil(1, 7)
 		)
 
 		@JvmStatic
-		fun numOfIntCharsAndStrings() = Tuple(
+		fun arbNumOfIntCharsAndStrings() = Tuple(
 			arb.intFromUntil(1, 5),
 			arb.intFromUntil(1, 7),
 			arb.intFromUntil(1, 6)
 		)
 
 		@JvmStatic
-		fun dynamicNumOfGeneratorsAndValues(): ArbArgsGenerator<List<Int>> =
+		fun arbNumOfGeneratorsAndValues(): ArbArgsGenerator<List<Int>> =
 			arb.intFromUntil(3, 7).combineDependent({ numOfGenerators ->
 				arb.intFromUntil(1, 7 - (numOfGenerators / 2)).chunked(numOfGenerators)
 			}) { _, list -> list }

--- a/src/test/kotlin/com/tegonal/minimalist/generators/ArbBoundsTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/ArbBoundsTest.kt
@@ -14,7 +14,6 @@ import com.tegonal.minimalist.providers.ArgsSource
 import com.tegonal.minimalist.utils.BigInt
 import com.tegonal.minimalist.utils.toBigInt
 import org.junit.jupiter.params.ParameterizedTest
-import kotlin.test.Test
 
 class ArbBoundsTest : AbstractArbArgsGeneratorTest<Any>() {
 
@@ -41,7 +40,7 @@ class ArbBoundsTest : AbstractArbArgsGeneratorTest<Any>() {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("intSafeMinMaxAndMinSize")
+	@ArgsSource("arbIntSafeMinMaxAndMinSize")
 	fun createIntMaxInIntDomain(minInclusive: Int, maxInclusive: Int, minSize: Int) {
 		arb.createIntDomainBasedBoundsArbGenerator(
 			minInclusive = minInclusive, maxInclusive = maxInclusive, minSize = minSize, maxSize = null
@@ -56,7 +55,7 @@ class ArbBoundsTest : AbstractArbArgsGeneratorTest<Any>() {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("intSafeMinMaxAndMinSize")
+	@ArgsSource("arbIntSafeMinMaxAndMinSize")
 	fun createMaxInIntDomain(minInclusive: Int, maxInclusive: Int, minSize: Int) {
 		val minInclusiveL = minInclusive.toLong()
 		val maxInclusiveL = maxInclusive.toLong()
@@ -73,7 +72,7 @@ class ArbBoundsTest : AbstractArbArgsGeneratorTest<Any>() {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("intSafeMinMaxAndMinSize")
+	@ArgsSource("arbIntSafeMinMaxAndMinSize")
 	fun createMaxInIntDomainButShifted(minInclusive: Int, maxInclusive: Int, minSize: Int) {
 		val intMaxAsLong = Int.MAX_VALUE.toLong()
 		val minInclusiveShifted = intMaxAsLong + minInclusive
@@ -94,7 +93,7 @@ class ArbBoundsTest : AbstractArbArgsGeneratorTest<Any>() {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("longSafeMinMaxAndMinSize")
+	@ArgsSource("arbLongSafeMinMaxAndMinSize")
 	fun createMaxInLongDomain(minInclusive: Long, maxInclusive: Long, minSize: Long) {
 		arb.createBoundsArbGenerator(
 			minInclusive = minInclusive, maxInclusive = maxInclusive, minSize = minSize, maxSize = null
@@ -109,7 +108,7 @@ class ArbBoundsTest : AbstractArbArgsGeneratorTest<Any>() {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("longUnsafeMinMaxAndSize")
+	@ArgsSource("arbLongUnsafeMinMaxAndSize")
 	fun createMaxOutsideLongDomain(minInclusive: Long, maxInclusive: Long, minSize: Long) {
 		arb.createBoundsArbGenerator(
 			minInclusive = minInclusive, maxInclusive = maxInclusive, minSize = minSize, maxSize = null
@@ -127,26 +126,26 @@ class ArbBoundsTest : AbstractArbArgsGeneratorTest<Any>() {
 
 	companion object {
 		@JvmStatic
-		fun intSafeMinMaxAndMinSize() =
-			intSafeMinMax().combineDependent {
+		fun arbIntSafeMinMaxAndMinSize() =
+			arbIntSafeMinMax().combineDependent {
 				arb.intFromTo(1, it.second - it.first + 1)
 			}
 
 		@JvmStatic
-		fun intSafeMinMax() =
+		fun arbIntSafeMinMax() =
 			// we are not using arb.intRange here on purpose as we would use the function under test in the test-setup
 			arb.intFromUntil(Int.MIN_VALUE, Int.MAX_VALUE - possibleMaxSizeSafeInIntDomain).combineDependent {
 				arb.intFromUntil(it, it + possibleMaxSizeSafeInIntDomain)
 			}
 
 		@JvmStatic
-		fun longSafeMinMaxAndMinSize() =
-			longSafeMinMax().combineDependent {
+		fun arbLongSafeMinMaxAndMinSize() =
+			arbLongSafeMinMax().combineDependent {
 				arb.longFromTo(1, it.second - it.first + 1)
 			}
 
 		@JvmStatic
-		fun longSafeMinMax() =
+		fun arbLongSafeMinMax() =
 			// we are not using arb.longRange here on purpose as we would use the function under test in the test-setup
 			arb.longFromUntil(Long.MIN_VALUE, Long.MAX_VALUE - possibleMaxSizeSafeInLongDomain).combineDependent {
 				// + possibleMaxSizeSafeInIntDomain as we could otherwise land in the Int-Domain
@@ -154,7 +153,7 @@ class ArbBoundsTest : AbstractArbArgsGeneratorTest<Any>() {
 			}
 
 		@JvmStatic
-		fun longUnsafeMinMaxAndSize() =
+		fun arbLongUnsafeMinMaxAndSize() =
 			arb.longFromUntil(Long.MIN_VALUE, Long.MAX_VALUE - possibleMaxSizeSafeInLongDomain - 10).combineDependent {
 				arb.longFromUntil(it + possibleMaxSizeSafeInLongDomain, Long.MAX_VALUE)
 			}.combineDependent {

--- a/src/test/kotlin/com/tegonal/minimalist/generators/ArbMergeWeightedTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/ArbMergeWeightedTest.kt
@@ -17,7 +17,7 @@ import org.junit.jupiter.params.ParameterizedTest
 class ArbMergeWeightedTest {
 
 	@ParameterizedTest
-	@ArgsSource("weightsInTotalAlways100")
+	@ArgsSource("arbWeightsInTotalAlways100")
 	fun `check weights are correct`(weights: List<Int>) {
 		val g1 = PseudoArbArgsGenerator(
 			(0..9).asSequence(),
@@ -45,7 +45,7 @@ class ArbMergeWeightedTest {
 
 
 	@ParameterizedTest
-	@ArgsSource("invalidWeight")
+	@ArgsSource("arbInvalidWeight")
 	fun invalidWeights(weight: Int) {
 		val g1 = arb.intFromUntil(1, 10)
 		val g2 = arb.intFromUntil(20, 30)
@@ -70,7 +70,7 @@ class ArbMergeWeightedTest {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("twoWeightsInTotalIntMaxOrMore")
+	@ArgsSource("arbTwoWeightsInTotalIntMaxOrMore")
 	fun `invalid total weights in case of 2`(weight1: Int, weight2: Int) {
 		val g1 = arb.intFromUntil(1, 10)
 		val g2 = arb.intFromUntil(20, 30)
@@ -83,7 +83,7 @@ class ArbMergeWeightedTest {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("threeWeightsInTotalIntMaxOrMore")
+	@ArgsSource("arbThreeWeightsInTotalIntMaxOrMore")
 	fun `invalid total weights in case of 3`(weight1: Int, weight2: Int, weight3: Int) {
 		val g1 = arb.intFromUntil(1, 10)
 		val g2 = arb.intFromUntil(20, 30)
@@ -98,7 +98,7 @@ class ArbMergeWeightedTest {
 
 	companion object {
 		@JvmStatic
-		fun weightsInTotalAlways100() = createMinimalistRandom().let { minimalistRandom ->
+		fun arbWeightsInTotalAlways100() = createMinimalistRandom().let { minimalistRandom ->
 			arb.intFromUntil(1, 10).map { numOfGenerators ->
 				mutableListOf<Int>().also { weights ->
 					val cumulativeWeight = (0 until numOfGenerators).fold(0) { cumulativeWeight, index ->
@@ -113,19 +113,19 @@ class ArbMergeWeightedTest {
 		}
 
 		@JvmStatic
-		fun invalidWeight() =
+		fun arbInvalidWeight() =
 			//TODO 2.1.0 introduce the concept of edge cases, here we would like to be sure that 0 is invalid as well
 			arb.intFromTo(Int.MIN_VALUE, 0)
 
 		@JvmStatic
-		fun twoWeightsInTotalIntMaxOrMore() =
+		fun arbTwoWeightsInTotalIntMaxOrMore() =
 			arb.intFromUntil(1, Int.MAX_VALUE).combineDependent {
 				arb.intFromTo(Int.MAX_VALUE - it, Int.MAX_VALUE)
 			}
 
 
 		@JvmStatic
-		fun threeWeightsInTotalIntMaxOrMore() =
+		fun arbThreeWeightsInTotalIntMaxOrMore() =
 			arb.intFromUntil(1, Int.MAX_VALUE).combineDependent {
 				arb.intFromUntil(1, Int.MAX_VALUE)
 			}.combineDependent({ (a, b) ->

--- a/src/test/kotlin/com/tegonal/minimalist/generators/ArbSeedOffsetTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/ArbSeedOffsetTest.kt
@@ -16,7 +16,7 @@ import kotlin.collections.map
 class ArbSeedOffsetTest {
 
 	@ParameterizedTest
-	@ArgsSource("offsets")
+	@ArgsSource("arb0To10")
 	fun mapIndexedTakesConfigDeterminedOffsetIntoAccount(offset: Int) {
 		val modifiedArb = createArbWithCustomConfig(
 			arb._components.config.copy { offsetToDecidedOffset = offset }
@@ -100,6 +100,6 @@ class ArbSeedOffsetTest {
 
 	companion object {
 		@JvmStatic
-		fun offsets() = arb.intFromUntil(0, 10)
+		fun arb0To10() = arb.intFromUntil(0, 10)
 	}
 }

--- a/src/test/kotlin/com/tegonal/minimalist/generators/OrderedCombineTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/OrderedCombineTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.params.ParameterizedTest
 class OrderedCombineTest : AbstractOrderedCombinerTest() {
 
 	@ParameterizedTest
-	@ArgsSource("numOfIntAndChars")
+	@ArgsSource("arbNumOfIntAndChars")
 	fun combine2(numOfInts: Int, numOfChars: Int) {
 		val a1s = (1..numOfInts).toList()
 		val a2s = (1..numOfChars).map { 'A' - 1 + it }
@@ -20,7 +20,7 @@ class OrderedCombineTest : AbstractOrderedCombinerTest() {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("numOfIntAndChars")
+	@ArgsSource("arbNumOfIntAndChars")
 	fun combineAll2(numOfInts: Int, numOfChars: Int) {
 		val a1s = (1..numOfInts).toList()
 		val a2s = (1..numOfChars).map { 'A' + it }
@@ -32,7 +32,7 @@ class OrderedCombineTest : AbstractOrderedCombinerTest() {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("numOfIntCharsAndStrings")
+	@ArgsSource("arbNumOfIntCharsAndStrings")
 	fun combine3(numOfInts: Int, numOfChars: Int, numOfStrings: Int) {
 		val a1s = (1..numOfInts).toList()
 		val a2s = (1..numOfChars).map { 'A' - 1 + it }
@@ -48,7 +48,7 @@ class OrderedCombineTest : AbstractOrderedCombinerTest() {
 
 
 	@ParameterizedTest
-	@ArgsSource("numOfIntCharsAndStrings")
+	@ArgsSource("arbNumOfIntCharsAndStrings")
 	fun combineAll3(numOfInts: Int, numOfChars: Int, numOfStrings: Int) {
 		val a1s = (1..numOfInts).toList()
 		val a2s = (1..numOfChars).map { 'A' + it }
@@ -64,7 +64,7 @@ class OrderedCombineTest : AbstractOrderedCombinerTest() {
 
 
 	@ParameterizedTest
-	@ArgsSource("dynamicNumOfGeneratorsAndValues")
+	@ArgsSource("arbNumOfGeneratorsAndValues")
 	fun dynamic(numOfValuesPerGenerator: List<Int>) {
 		val values: List<List<Any>> = numOfValuesPerGenerator.mapIndexed { index, numOfValues ->
 			when (index % 3) {

--- a/src/test/kotlin/com/tegonal/minimalist/generators/OrderedConcatenateAllTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/OrderedConcatenateAllTest.kt
@@ -34,6 +34,6 @@ class OrderedConcatenateAllTest : AbstractOrderedConcatenateTest() {
 		expect {
 			seq.iterator()
 		}.toThrow<IllegalStateException> { messageToContain("can be consumed only once") }
-		expect(concatenated.generate().take(11).toList()).toContainExactly(1, 2, 3, 4, 10, 11, 1, 2, 3, 4, 10)
+		expect(concatenated.generate(offset = 0).take(11).toList()).toContainExactly(1, 2, 3, 4, 10, 11, 1, 2, 3, 4, 10)
 	}
 }

--- a/src/test/kotlin/com/tegonal/minimalist/generators/OrderedTupleLikeCombineTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/OrderedTupleLikeCombineTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.ParameterizedTest
 class OrderedTupleLikeCombineTest : AbstractOrderedCombinerTest() {
 
 	@ParameterizedTest
-	@ArgsSource("numOfIntAndChars")
+	@ArgsSource("arbNumOfIntAndChars")
 	fun combineAll_Pair(numOfInts: Int, numOfChars: Int) {
 		val a1s = (1..numOfInts).toList()
 		val a2s = (1..numOfChars).map { 'A' + it }
@@ -22,7 +22,7 @@ class OrderedTupleLikeCombineTest : AbstractOrderedCombinerTest() {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("numOfIntCharsAndStrings")
+	@ArgsSource("arbNumOfIntCharsAndStrings")
 	fun combineAll_Triple(numOfInts: Int, numOfChars: Int, numOfStrings: Int) {
 		val a1s = (1..numOfInts).toList()
 		val a2s = (1..numOfChars).map { 'A' + it }
@@ -37,7 +37,7 @@ class OrderedTupleLikeCombineTest : AbstractOrderedCombinerTest() {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("numOfIntCharsAndStrings")
+	@ArgsSource("arbNumOfIntCharsAndStrings")
 	fun combineAll_Tuple4Like(numOfInts: Int, numOfChars: Int, numOfStrings: Int) {
 		val a1s = (1..numOfInts).toList()
 		val a2s = (1..numOfChars).map { 'A' + it }

--- a/src/test/kotlin/com/tegonal/minimalist/generators/SemiOrderedCombineTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/SemiOrderedCombineTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.Test
 class SemiOrderedCombineTest : AbstractOrderedCombinerTest() {
 
 	@ParameterizedTest
-	@ArgsSource("numOfIntAndChars")
+	@ArgsSource("arbNumOfIntAndChars")
 	fun combine2(numOfInts: Int, numOfChars: Int) {
 		val a1s = (1..numOfInts).toList()
 		val a2s = (1..numOfChars).map { 'A' + it }
@@ -23,7 +23,7 @@ class SemiOrderedCombineTest : AbstractOrderedCombinerTest() {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("numOfIntAndChars")
+	@ArgsSource("arbNumOfIntAndChars")
 	fun combineAll2(numOfInts: Int, numOfChars: Int) {
 		val a1s = (1..numOfInts).toList()
 		val a2s = (1..numOfChars).map { 'A' + it }
@@ -35,7 +35,7 @@ class SemiOrderedCombineTest : AbstractOrderedCombinerTest() {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("numOfIntCharsAndStrings")
+	@ArgsSource("arbNumOfIntCharsAndStrings")
 	fun combine3(numOfInts: Int, numOfChars: Int, numOfStrings: Int) {
 		val a1s = (1..numOfInts).toList()
 		val a2s = (1..numOfChars).map { 'A' + it }
@@ -50,7 +50,7 @@ class SemiOrderedCombineTest : AbstractOrderedCombinerTest() {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("numOfIntCharsAndStrings")
+	@ArgsSource("arbNumOfIntCharsAndStrings")
 	fun combineAll3(numOfInts: Int, numOfChars: Int, numOfStrings: Int) {
 		val a1s = (1..numOfInts).toList()
 		val a2s = (1..numOfChars).map { 'A' + it }
@@ -65,7 +65,7 @@ class SemiOrderedCombineTest : AbstractOrderedCombinerTest() {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("dynamicNumOfGeneratorsAndValues")
+	@ArgsSource("arbNumOfGeneratorsAndValues")
 	fun dynamic(numOfValuesPerGenerator: List<Int>) {
 		val values: List<List<Any>> = numOfValuesPerGenerator.mapIndexed { index, numOfValues ->
 			when (index % 3) {
@@ -106,5 +106,6 @@ class SemiOrderedCombineTest : AbstractOrderedCombinerTest() {
 		expect(generator.generateToList(5)).toContainExactlyElementsOf(fourCombined + oneCombined)
 	}
 
-	fun <T> SemiOrderedArgsGenerator<T>.generateToList(amount: Int): List<T> = generate().take(amount).toList()
+	fun <T> SemiOrderedArgsGenerator<T>.generateToList(amount: Int): List<T> =
+		generate(offset = 0).take(amount).toList()
 }

--- a/src/test/kotlin/com/tegonal/minimalist/generators/SemiOrderedConcatenateAllTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/SemiOrderedConcatenateAllTest.kt
@@ -40,6 +40,6 @@ class SemiOrderedConcatenateAllTest : AbstractOrderedConcatenateTest() {
 		expect {
 			seq.iterator()
 		}.toThrow<IllegalStateException> { messageToContain("can be consumed only once") }
-		expect(concatenated.generate().take(11).toList()).toContainExactly(1, 2, 3, 4, 10, 11, 1, 2, 3, 4, 10)
+		expect(concatenated.generate(offset = 0).take(11).toList()).toContainExactly(1, 2, 3, 4, 10, 11, 1, 2, 3, 4, 10)
 	}
 }

--- a/src/test/kotlin/com/tegonal/minimalist/generators/SemiOrderedTupleLikeCombineTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/SemiOrderedTupleLikeCombineTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.ParameterizedTest
 class SemiOrderedTupleLikeCombineTest : AbstractOrderedCombinerTest() {
 
 	@ParameterizedTest
-	@ArgsSource("numOfIntAndChars")
+	@ArgsSource("arbNumOfIntAndChars")
 	fun combineAll_Pair(numOfInts: Int, numOfChars: Int) {
 		val a1s = (1..numOfInts).toList()
 		val a2s = (1..numOfChars).map { 'A' + it }
@@ -22,7 +22,7 @@ class SemiOrderedTupleLikeCombineTest : AbstractOrderedCombinerTest() {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("numOfIntCharsAndStrings")
+	@ArgsSource("arbNumOfIntCharsAndStrings")
 	fun combineAll_Triple(numOfInts: Int, numOfChars: Int, numOfStrings: Int) {
 		val a1s = (1..numOfInts).toList()
 		val a2s = (1..numOfChars).map { 'A' + it }
@@ -37,7 +37,7 @@ class SemiOrderedTupleLikeCombineTest : AbstractOrderedCombinerTest() {
 	}
 
 	@ParameterizedTest
-	@ArgsSource("numOfIntCharsAndStrings")
+	@ArgsSource("arbNumOfIntCharsAndStrings")
 	fun combineAll_Tuple4Like(numOfInts: Int, numOfChars: Int, numOfStrings: Int) {
 		val a1s = (1..numOfInts).toList()
 		val a2s = (1..numOfChars).map { 'A' + it }

--- a/src/test/kotlin/com/tegonal/minimalist/providers/ProfileBasedArgsRangeDeciderTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/providers/ProfileBasedArgsRangeDeciderTest.kt
@@ -39,14 +39,14 @@ class ProfileBasedArgsRangeDeciderTest {
 	)
 
 	@ParameterizedTest
-	@ArgsSource("categoryLevelAndGeneratorSize")
+	@ArgsSource("testTypeEnvAndGeneratorSize")
 	fun activeLevel_takeMatchesMaxArgsOfLevelUnlessArgsGeneratorSizeIsSmaller(
-		profile: TestType,
+		testType: TestType,
 		env: Env,
 		argsGeneratorSize: Int
 	) {
 		val customConfig = MinimalistConfig().copy {
-			defaultProfile = profile.name
+			defaultProfile = testType.name
 			activeEnv = env.name
 			testProfiles = ownTestProfiles.toHashMap()
 		}
@@ -63,7 +63,7 @@ class ProfileBasedArgsRangeDeciderTest {
 			feature(ArgsRange::take).toEqual(
 				minOf(
 					argsGeneratorSize,
-					ownTestProfiles.get(profile.name, env.name).maxArgs
+					ownTestProfiles.get(testType.name, env.name).maxArgs
 				)
 			)
 		}
@@ -128,7 +128,7 @@ class ProfileBasedArgsRangeDeciderTest {
 	companion object {
 
 		@JvmStatic
-		fun categoryLevelAndGeneratorSize() = Tuple(
+		fun testTypeEnvAndGeneratorSize() = Tuple(
 			ordered.fromEnum<TestType>(),
 			ordered.fromEnum<Env>(),
 			ordered.fromRange(1..11),


### PR DESCRIPTION
require that one passes an offset explicitly otherwise one might think that an offset is chosen magically (like when using ArgsSource)

moreover:
- always use `arb` as suffix in `ArgsSource` when creating an ArbArgsGenerator
- add doc for PredefinedArgsProviders



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/minimalist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
