### PR TITLE
fix arb.string check we are able to produce lengths, don't exceed

### DIFF
--- a/src/main/kotlin/com/tegonal/minimalist/generators/arbString.kt
+++ b/src/main/kotlin/com/tegonal/minimalist/generators/arbString.kt
@@ -11,6 +11,10 @@ import kotlin.random.Random
  *
  * You can use one of the predefined [UnicodeRanges.ranges] such as [UnicodeRanges.ASCII_PRINTABLE]
  *
+ * @param maxLength defines the maximum length the string can have.
+ * @param minLength defined the minimum length the string shall have.
+ * @param allowedRanges [UnicodeRange] ranges.
+ *
  * @since 2.0.0
  */
 fun ArbExtensionPoint.string(
@@ -25,49 +29,133 @@ fun ArbExtensionPoint.string(
 	require(allowedRanges.isNotEmpty()) {
 		"you need to define at least one ${UnicodeRange::class.simpleName}"
 	}
-	val nextCodePoint: Random.() -> Int = when (allowedRanges.size) {
-		1 -> allowedRanges.first().let { { nextInt(it.start, it.endInclusive + 1) } }
-		else -> {
-			{
-				val sizes = allowedRanges.map {
-					// Int is safe for Unicode  no need to convert toLong() (unless someone defined overlapping ranges,
-					// we ignore this case here, if it overflows then it can be seen as consequential bug)
-					it.endInclusive - it.start + 1
-				}
+	// we check in createNextRandomCodePointFun if the given allowedRanges allow to generate a string with minLength/maxLength
 
-				val cumulativeSizes = sizes.runningReduce(Int::plus)
-				val totalSize = cumulativeSizes.last()
-				val index = nextInt(totalSize)
-				cumulativeSizes.binarySearch(index).let {
-					if (it >= 0) {
-						// the randomly chosen index was exactly the cumulative size of a range
-						// i.e. we don't need to calculate the range offset
-						allowedRanges[it].start
-					} else {
-						//  binarySearch returned the `inverted insertion point` and we invert it again to retrieve
-						//  the rangeIndex where the cumulative size was greater than index
-						val rangeIndex = -it - 1
-						val range = allowedRanges[rangeIndex]
-						// but that means that we need to calculate the offset in that range
-						val cumulativeSizeOfPreviousRange = if (rangeIndex == 0) 0 else cumulativeSizes[rangeIndex - 1]
-						val offsetInRange = index - cumulativeSizeOfPreviousRange
-						range.start + offsetInRange
-					}
-				}
-			}
-		}
-	}
+	val (nextCodePoint, nextBmpCodePoint) = createNextRandomCodePointFun(allowedRanges, minLength, maxLength)
 
 	val componentFactoryContainer = _components
 	return intFromTo(minLength, maxLength).mapIndexed { index, length, seedOffset ->
-		componentFactoryContainer.createMinimalistRandom(seedBaseOffset + seedOffset + index).let { random ->
-			val sb = StringBuilder(length * 2)
-			repeat(length) {
+		// +1 so we don't use the same seed as intFromTo otherwise for the first string it will always be:
+		// length of the resulting string = first code point
+		componentFactoryContainer.createMinimalistRandom(seedBaseOffset + seedOffset + index + 1).let { random ->
+			val sb = StringBuilder(length)
+			var count = 0
+
+			while (count + 2 <= length) {
 				val codePoint = random.nextCodePoint()
 				sb.appendCodePoint(codePoint)
+				count += if (Character.isBmpCodePoint(codePoint)) 1 else 2
+			}
+
+			// can only happen if the requested length == minLength and minLength is odd
+			// in such a case we exit early in the while loop as non-bpm chars would exceed the chosen `length`, which
+			// means if length=maxLength then we would generate a string which is longer than requested
+			if (sb.length < minLength) {
+				if (nextBmpCodePoint != null) {
+					val codePoint = random.nextBmpCodePoint()
+					sb.appendCodePoint(codePoint)
+				} else {
+					error("buggy constellation detected, nextBmpCodePoint is null but we were not able to reach length $minLength - i.e. checkCanGenerateRequiredLength doesn't seem to work correctly")
+				}
 			}
 			sb.toString()
 		}
+	}
+}
+
+private fun createNextRandomCodePointFun(
+	allowedRanges: Array<out UnicodeRange>,
+	minLength: Int,
+	maxLength: Int
+): Pair<Random.() -> Int, (Random.() -> Int)?> = when (allowedRanges.size) {
+	1 -> allowedRanges.first().let { range ->
+		val isBmpRange = range.isBmpRange()
+		checkCanGenerateRequiredLength(
+			minLength = minLength,
+			maxLength = maxLength,
+			hasAtLeastOneBmpRange = isBmpRange
+		)
+		val lambda: Random.() -> Int = { nextInt(range.start, range.endInclusive + 1) }
+		lambda to lambda.takeIf { range.isBmpRange() }
+	}
+
+	else -> {
+		val (bmpRanges, nonBmpRanges) = allowedRanges.partition {
+			Character.isBmpCodePoint(it.start)
+		}
+
+		val hasBmpRange = bmpRanges.isNotEmpty()
+		checkCanGenerateRequiredLength(
+			minLength = minLength,
+			maxLength = maxLength,
+			hasAtLeastOneBmpRange = hasBmpRange
+		)
+
+		fun sizes(range: List<UnicodeRange>) =
+			range.map {
+				// Int is safe for Unicode, no need to convert toLong() (unless someone defined overlapping ranges,
+				// we ignore this case here, if it overflows then it can be seen as consequential bug)
+				it.endInclusive - it.start + 1
+			}
+
+		val bmpSizes = sizes(bmpRanges)
+		val nonBmpSizes = sizes(nonBmpRanges)
+
+		val bmpCumulativeSizes = bmpSizes.runningReduce(Int::plus)
+		val bmpTotalSize = bmpCumulativeSizes.last()
+		val (cumulativeSizes, totalSize) = when (nonBmpSizes.size) {
+			0 -> bmpCumulativeSizes to bmpTotalSize
+			1 -> (nonBmpSizes.first() + bmpTotalSize).let { (bmpCumulativeSizes + listOf(it)) to it }
+			else -> run {
+				bmpCumulativeSizes +
+					(listOf(nonBmpSizes.first() + bmpTotalSize) + nonBmpSizes.drop(1)).runningReduce(Int::plus)
+			}.let {
+				it to it.last()
+			}
+		}
+
+		Pair(
+			{
+				nextCodepoint(allowedRanges, cumulativeSizes, totalSize)
+			},
+			{
+				nextCodepoint(bmpRanges.toTypedArray(), bmpCumulativeSizes, bmpTotalSize)
+			}
+		)
+	}
+}
+
+private fun Random.nextCodepoint(ranges: Array<out UnicodeRange>, cumulativeSizes: List<Int>, totalSize: Int): Int {
+	//TODO 2.1.0 bench if it would be faster to use linear search in case there are not many allowedRanges
+	val index = nextInt(totalSize)
+	return cumulativeSizes.binarySearch(index).let {
+		if (it >= 0) {
+			// the randomly chosen index was exactly the cumulative size of a range
+			// i.e. we don't need to calculate the range offset
+			ranges[it].start
+		} else {
+			//  binarySearch returned the `inverted insertion point` and we invert it again to retrieve
+			//  the rangeIndex where the cumulative size was greater than index
+			val rangeIndex = -it - 1
+			val range = ranges[rangeIndex]
+			// but that means that we need to calculate the offset in that range
+			val cumulativeSizeOfPreviousRange = if (rangeIndex == 0) 0 else cumulativeSizes[rangeIndex - 1]
+			val offsetInRange = index - cumulativeSizeOfPreviousRange
+			range.start + offsetInRange
+		}
+	}
+}
+
+private fun checkCanGenerateRequiredLength(
+	minLength: Int,
+	maxLength: Int,
+	hasAtLeastOneBmpRange: Boolean
+) {
+	require(hasAtLeastOneBmpRange || minLength % 2 == 0) {
+		"minLength (${minLength}) is odd but none of the allowedRanges is in the BPM domain, which means Minimalist will not be able to generate such a string"
+	}
+	require(hasAtLeastOneBmpRange || maxLength % 2 == 0) {
+		"maxLength (${maxLength}) is odd but none of the allowedRanges is in the BPM domain, which means Minimalist will not be able to generate such a string"
 	}
 }
 

--- a/src/test/kotlin/com/tegonal/minimalist/generators/ArbStringTest.kt
+++ b/src/test/kotlin/com/tegonal/minimalist/generators/ArbStringTest.kt
@@ -1,6 +1,19 @@
 package com.tegonal.minimalist.generators
 
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import ch.tutteli.atrium.api.verbs.expect
 import ch.tutteli.kbox.Tuple
+import com.tegonal.minimalist.config._components
+import com.tegonal.minimalist.config.arb
+import com.tegonal.minimalist.config.config
+import com.tegonal.minimalist.providers.ArgsSource
+import com.tegonal.minimalist.providers.ArgsSourceOptions
+import com.tegonal.minimalist.testutils.createArbWithCustomConfig
+import com.tegonal.minimalist.testutils.withMockedRandom
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.params.ParameterizedTest
 
 class ArbStringTest : AbstractArbArgsGeneratorTest<Any>() {
 
@@ -27,5 +40,102 @@ class ArbStringTest : AbstractArbArgsGeneratorTest<Any>() {
 		(range.start..range.endInclusive).map {
 			StringBuilder().appendCodePoint(it).toString()
 		}
+	}
+
+	@ParameterizedTest
+	@ArgsSource("arb1To20")
+	@ArgsSourceOptions(maxArgs = 5)
+	fun failsIMinLengthIsOddAndMultipleNonBmpRange(numberOfUnicodeRanges: Int) {
+		expect {
+			arb.string(
+				minLength = 1, maxLength = 2,
+				allowedRanges = (1..numberOfUnicodeRanges).map {
+					UnicodeRange(
+						UnicodeRange.NON_BMP_START + it * 10,
+						UnicodeRange.NON_BMP_START + it * 10 + 6
+					)
+				}.toTypedArray()
+			)
+		}.toThrow<IllegalArgumentException> {
+			messageToContain("minLength (1) is odd", "none of the allowedRanges is in the BPM domain")
+		}
+	}
+
+	@Test
+	fun minLength1CheckFallbackToBmpWorks() {
+		val g = arb.string(
+			minLength = 1,
+			maxLength = 1,
+			allowedRanges = arrayOf(
+				// the chances that A get's picked are quite low, hence it should be enough to have just one Test
+				UnicodeRange('A', 'A'),
+				UnicodeRange(UnicodeRange.NON_BMP_START, UnicodeRange.MAX_CODE_POINT)
+			)
+		)
+		expect(g.generateOne(seedOffset = 0)).toEqual("A")
+	}
+
+	@Test
+	fun checkFallbackWorksIfTwoAreGenerated() {
+		val modifiedArb =
+			createArbWithCustomConfig(arb._components.config.copy { seed = 0 })._components.withMockedRandom { seed ->
+				// seed = 0 is the length
+				if (seed == 0) Tuple(listOf(3), emptyList(), emptyList())
+				// everything else are the code points
+				else Tuple(listOf(0xF602 + 1, 1), emptyList(), emptyList())
+			}.arb
+
+
+		val g = modifiedArb.string(
+			minLength = 3,
+			maxLength = 6,
+			allowedRanges = arrayOf(
+				UnicodeRange('A', 'A'),
+				UnicodeRange(UnicodeRange.NON_BMP_START, UnicodeRange.MAX_CODE_POINT)
+			)
+		)
+		expect(g.generateOne(seedOffset = 0)).toEqual("\uD83D\uDE02A")
+	}
+
+	@TestFactory
+	fun checkGenerationForLength1To20Works() =
+		ordered.intFromTo(1, 20).combineDependent { length ->
+			arb.string(
+				minLength = length,
+				maxLength = length,
+				allowedRanges = arrayOf(
+					UnicodeRange('A', 'Z'),
+					UnicodeRange(UnicodeRange.NON_BMP_START, UnicodeRange.MAX_CODE_POINT)
+				)
+			)
+		}.generateAndTakeBasedOnDecider().map { (length, string) ->
+			dynamicTest("length $length") {
+				expect(string).feature("length") { this.length }.toEqual(length)
+			}
+		}
+
+	@TestFactory
+	fun checkGenerationWorksIfOnlyNonBmp() =
+		ordered.fromProgression(2..20 step 2).combineDependent { length ->
+			arb.string(
+				minLength = length,
+				maxLength = length + 6,
+				allowedRanges = arrayOf(
+					UnicodeRange(UnicodeRange.NON_BMP_START, UnicodeRange.MAX_CODE_POINT)
+				)
+			)
+		}.generateAndTakeBasedOnDecider().map { (length, string) ->
+			dynamicTest("length $length .. ${length + 6}") {
+				expect(string).feature("length", { this.length }) {
+					feature("to be even") { this % 2 == 0 }.toEqual(true)
+					toBeGreaterThanOrEqualTo(length)
+					toBeLessThanOrEqualTo(length + 6)
+				}
+			}
+		}
+
+	companion object {
+		@JvmStatic
+		fun arb1To20() = arb.intFromTo(1, 20)
 	}
 }


### PR DESCRIPTION
- take into account that non-BMP code points will take up 2 chars (not only in StringBuilder, also in what we generate)
- check if we are able to generate min/maxLength, e.g. we cannot produce a string with minLength = odd if there aren't any BMP code points available
- in order that the implementation is simpler and more efficient, we define that a UnicodeRange either has to stay in th BMP domain or outside the BPM domain (i.e. start and endInclusive are in the same domain)



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/minimalist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
