### PR TITLE
introduce CoreSemiOrderedArgsGenerator with seedBaseOffset

### DIFF
--- a/src/jmh/kotlin/com/tegonal/variist/Cartesian3Bench.kt
+++ b/src/jmh/kotlin/com/tegonal/variist/Cartesian3Bench.kt
@@ -1,7 +1,8 @@
+@file:Suppress("unused")
+
 package com.tegonal.variist
 
 import ch.tutteli.kbox.Tuple3
-import com.tegonal.variist.config._components
 import com.tegonal.variist.generators.*
 import com.tegonal.variist.generators.impl.BaseSemiOrderedArgsGenerator
 import org.openjdk.jmh.annotations.*
@@ -80,7 +81,7 @@ abstract class CartesianProductMultiArgsGenerator<R>(
 	// note, we don't (and cannot) check that a1Generator and a2Generator use the same ComponentContainer,
 	// should you run into weird behaviour (such as one generator uses seed X and the other seed Y) then most likely
 	// someone used two different initial factories
-	generators.first()._components,
+	generators.first()._core,
 	generators.fold(1L) { acc, gen -> acc * gen.size }
 ) {
 	private val numOfGenerators = generators.size

--- a/src/jmh/kotlin/com/tegonal/variist/CartesianBench.kt
+++ b/src/jmh/kotlin/com/tegonal/variist/CartesianBench.kt
@@ -1,7 +1,7 @@
+@file:Suppress("unused")
 package com.tegonal.variist
 
 import ch.tutteli.kbox.Tuple2
-import com.tegonal.variist.config._components
 import com.tegonal.variist.generators.*
 import com.tegonal.variist.generators.impl.BaseSemiOrderedArgsGenerator
 import com.tegonal.variist.generators.impl.OrderedCartesianProductArgsGenerator
@@ -142,7 +142,7 @@ class Radix<A, B, R>(
 	a: OrderedArgsGenerator<A>,
 	private val b: OrderedArgsGenerator<B>,
 	private val transform: (A, B) -> R
-) : BaseSemiOrderedArgsGenerator<R>(a._components, a.size.toLong() * b.size.toLong()) {
+) : BaseSemiOrderedArgsGenerator<R>(a._core, a.size.toLong() * b.size.toLong()) {
 	val aL = a.toList()
 	val aSize = a.size
 	val bSize = b.size
@@ -168,7 +168,7 @@ class SmallerBiggerArgsGenerator<A1, A2, R>(
 	// note, we don't (and cannot) check that a1Generator and a2Generator use the same ComponentContainer,
 	// should you run into weird behaviour (such as one generator uses seed X and the other seed Y) then most likely
 	// someone used two different initial factories
-	a1Generator._components,
+	a1Generator._core,
 	a1Generator.size.toLong() * a2Generator.size.toLong()
 ) {
 	private val a2Size: Int = a2Generator.size

--- a/src/jmh/kotlin/com/tegonal/variist/IntFromUntilBench.kt
+++ b/src/jmh/kotlin/com/tegonal/variist/IntFromUntilBench.kt
@@ -1,3 +1,4 @@
+@file:Suppress("unused")
 package com.tegonal.variist
 
 import ch.tutteli.kbox.identity
@@ -27,8 +28,8 @@ open class IntFromUntilBench {
 	// argsProvider. withIdentity is about 0.4 - 0.5 faster than withoutPlusMap (memory about the same).
 	// That's not enough to keep the complexity, for now we use only an approach which does not require argsProvider
 	@Benchmark
-	fun withIdentity() = IntFromUntilWithIdentityArgsProvider(ordered._components, 0, 1000, 1,::identity)
-			.generateAndTake(argsRange).count()
+	fun withIdentity() = IntFromUntilWithIdentityArgsProvider(ordered._components, 0, 1000, 1, ::identity)
+		.generateAndTake(argsRange).count()
 
 	@Benchmark
 	fun without(): Int = IntFromUntilWithoutArgsProvider(ordered._components, 0, 1000, 1)
@@ -54,6 +55,7 @@ class IntFromUntilWithIdentityArgsProvider<T>(
 	private val argsProvider: (Int) -> T
 ) : BaseSemiOrderedArgsGenerator<T>(
 	componentFactoryContainer,
+	seedBaseOffset = 0,
 	run {
 		// we first check the numbers before calculating the size as the size would be wrong
 		// if the invariants are not given
@@ -77,6 +79,7 @@ class IntFromUntilWithoutArgsProvider(
 	private val step: Int,
 ) : BaseSemiOrderedArgsGenerator<Int>(
 	componentFactoryContainer,
+	seedBaseOffset = 0,
 	run {
 		// we first check the numbers before calculating the size as the size would be wrong
 		// if the invariants are not given
@@ -120,6 +123,7 @@ class IntFromUntilWithoutArgsProviderWithIntFromUntilIterator(
 	private val step: Int,
 ) : BaseSemiOrderedArgsGenerator<Int>(
 	componentFactoryContainer,
+	seedBaseOffset = 0,
 	run {
 		// we first check the numbers before calculating the size as the size would be wrong
 		// if the invariants are not given

--- a/src/main/kotlin/com/tegonal/variist/config/componentFactoryContainerExtensions.kt
+++ b/src/main/kotlin/com/tegonal/variist/config/componentFactoryContainerExtensions.kt
@@ -80,14 +80,22 @@ fun ComponentFactoryContainer.createVariistRandom(seedOffset: Int): Random =
  *
  * @since 2.0.0
  */
-val ComponentFactoryContainer.ordered get() : OrderedExtensionPoint = DefaultOrderedExtensionPoint(this)
+val ComponentFactoryContainer.ordered
+	get() : OrderedExtensionPoint = DefaultOrderedExtensionPoint(
+		this,
+		// -1 because an OrderedArgsGenerator does not have an unknown part yet, i.e. if we combine it somehow with an
+		// ArbArgsGenerator, then the resulting SemiOrderedArgsGenerator will have seedBaseOffset per default because
+		// we do seedBaseOffset + 1 in BaseSemiOrderedArgsGenerator
+		seedBaseOffset = -1
+	)
 
 /**
  * Creates an [SemiOrderedExtensionPoint] based on this [ComponentFactoryContainer].
  *
  * @since 2.0.0
  */
-val ComponentFactoryContainer.semiOrdered get() : SemiOrderedExtensionPoint = DefaultSemiOrderedExtensionPoint(this)
+val ComponentFactoryContainer.semiOrdered
+	get() : SemiOrderedExtensionPoint = DefaultSemiOrderedExtensionPoint(this, seedBaseOffset = 0)
 
 /**
  * Creates an [ArbExtensionPoint] based on this [ComponentFactoryContainer].

--- a/src/main/kotlin/com/tegonal/variist/generators/ArbArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/ArbArgsGenerator.kt
@@ -3,6 +3,8 @@ package com.tegonal.variist.generators
 import com.tegonal.variist.config.ComponentFactoryContainerProvider
 import com.tegonal.variist.config.VariistConfig
 import com.tegonal.variist.generators.impl.DefaultArbExtensionPoint
+import com.tegonal.variist.generators.impl.DefaultOrderedExtensionPoint
+import com.tegonal.variist.generators.impl.DefaultSemiOrderedExtensionPoint
 import com.tegonal.variist.utils.createVariistRandom
 
 /**
@@ -42,7 +44,7 @@ interface ArbArgsGenerator<out T> : ArgsGenerator<T> {
 }
 
 /**
- * Represents an interface each [ArbArgsGenerator] should implement and providing additional core functionality which
+ * Represents an interface each [ArbArgsGenerator] must implement which provides additional core functionality which
  * is relevant for users which create own [ArbArgsGenerator]s or combiner functions.
  *
  * The separation between [ArbArgsGenerator] and [CoreArbArgsGenerator] makes sure the API stays clean for
@@ -61,6 +63,22 @@ interface CoreArbArgsGenerator<out T> : ArbArgsGenerator<T>, ComponentFactoryCon
  */
 val <T> CoreArbArgsGenerator<T>.arb: ArbExtensionPoint
 	get() = DefaultArbExtensionPoint(componentFactoryContainer, seedBaseOffset)
+
+/**
+ * Creates an [SemiOrderedExtensionPoint] based on `this` [CoreArbArgsGenerator].
+ *
+ * @since 2.3.0
+ */
+val <T> CoreArbArgsGenerator<T>.semiOrdered: SemiOrderedExtensionPoint
+	get() = DefaultSemiOrderedExtensionPoint(componentFactoryContainer, seedBaseOffset)
+
+/**
+ * Creates an [OrderedExtensionPoint] based on `this` [CoreArbArgsGenerator].
+ *
+ * @since 2.3.0
+ */
+val <T> CoreArbArgsGenerator<T>.ordered: OrderedExtensionPoint
+	get() = DefaultOrderedExtensionPoint(componentFactoryContainer, seedBaseOffset)
 
 /**
  * Casts `this` to a [CoreArbArgsGenerator].

--- a/src/main/kotlin/com/tegonal/variist/generators/SemiOrderedArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/SemiOrderedArgsGenerator.kt
@@ -1,5 +1,10 @@
 package com.tegonal.variist.generators
 
+import com.tegonal.variist.config.ComponentFactoryContainerProvider
+import com.tegonal.variist.generators.impl.DefaultArbExtensionPoint
+import com.tegonal.variist.generators.impl.DefaultOrderedExtensionPoint
+import com.tegonal.variist.generators.impl.DefaultSemiOrderedExtensionPoint
+
 /**
  * Represents an [ArgsGenerator] which provides the method [generate] where some part of [T] is always in the
  * same order and a finite number before repeating and another part of [T] is undefined (could be ordered and finite,
@@ -30,3 +35,53 @@ interface SemiOrderedArgsGenerator<out T> : ArgsGenerator<T> {
 	 */
 	fun generate(offset: Int): Sequence<T>
 }
+
+/**
+ * Represents an interface each [SemiOrderedArgsGenerator] must implement which provides additional core functionality
+ * which is relevant for users which create own [SemiOrderedArgsGenerator]s or combiner functions.
+ *
+ * The separation between [SemiOrderedArgsGenerator] and [CoreSemiOrderedArgsGenerator] makes sure the API stays clean
+ * for regular users which just use [ordered]/[semiOrdered] but don't define own
+ * [SemiOrderedArgsGenerator] implementations.
+ *
+ * @since 2.3.0
+ */
+interface CoreSemiOrderedArgsGenerator<out T> : SemiOrderedArgsGenerator<T>, ComponentFactoryContainerProvider {
+	val seedBaseOffset: Int
+}
+
+/**
+ * Creates an [ArbExtensionPoint] based on `this` [CoreSemiOrderedArgsGenerator].
+ *
+ * @since 2.3.0
+ */
+val <T> CoreSemiOrderedArgsGenerator<T>.arb: ArbExtensionPoint
+	get() = DefaultArbExtensionPoint(componentFactoryContainer, seedBaseOffset)
+
+/**
+ * Creates an [SemiOrderedExtensionPoint] based on `this` [CoreSemiOrderedArgsGenerator].
+ *
+ * @since 2.3.0
+ */
+val <T> CoreSemiOrderedArgsGenerator<T>.semiOrdered: SemiOrderedExtensionPoint
+	get() = DefaultSemiOrderedExtensionPoint(componentFactoryContainer, seedBaseOffset)
+
+/**
+ * Creates an [OrderedExtensionPoint] based on `this` [CoreSemiOrderedArgsGenerator].
+ *
+ * @since 2.3.0
+ */
+val <T> CoreSemiOrderedArgsGenerator<T>.ordered: OrderedExtensionPoint
+	get() = DefaultOrderedExtensionPoint(componentFactoryContainer, seedBaseOffset)
+
+/**
+ * Casts `this` to a [CoreArbArgsGenerator].
+ *
+ * @since 2.0.0
+ */
+@Suppress("ObjectPropertyName")
+val <T> SemiOrderedArgsGenerator<T>._core: CoreSemiOrderedArgsGenerator<T>
+	get() = when (this) {
+		is CoreSemiOrderedArgsGenerator<T> -> this
+		else -> error("The ${SemiOrderedArgsGenerator::class.simpleName} ${this::class.qualifiedName} does not implement ${CoreSemiOrderedArgsGenerator::class.qualifiedName}, please inform the author.")
+	}

--- a/src/main/kotlin/com/tegonal/variist/generators/generatorFactoryExtensionPoints.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/generatorFactoryExtensionPoints.kt
@@ -12,6 +12,16 @@ interface GeneratorExtensionPoint : IsComponentFactoryContainerProvider {
 	val arb: ArbExtensionPoint
 	val ordered: OrderedExtensionPoint
 	val semiOrdered: SemiOrderedExtensionPoint
+
+	/**
+	 * Shall be used as seedBaseOffset.
+	 *
+	 * By [ArbArgsGenerator] as [CoreArbArgsGenerator.seedBaseOffset].
+	 * By [SemiOrderedArgsGenerator] as [CoreSemiOrderedArgsGenerator.seedBaseOffset]
+	 *
+	 * @since 2.3.0 (moved up, was only in [ArbExtensionPoint] since 2.0.0)
+	 */
+	val seedBaseOffset: Int
 }
 
 /**
@@ -34,12 +44,7 @@ interface SemiOrderedExtensionPoint : GeneratorExtensionPoint
  *
  * @since 2.0.0
  */
-interface ArbExtensionPoint : GeneratorExtensionPoint {
-	/**
-	 * Shall be used by [ArbArgsGenerator] as [CoreArbArgsGenerator.seedBaseOffset].
-	 */
-	val seedBaseOffset: Int
-}
+interface ArbExtensionPoint : GeneratorExtensionPoint
 
 private val propertiesBasedComponentFactoryContainer: ComponentFactoryContainer = run {
 	val config = VariistConfigViaPropertiesLoader().config

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/ArrayOrderedArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/ArrayOrderedArgsGenerator.kt
@@ -15,8 +15,9 @@ import com.tegonal.variist.utils.repeatForever
  */
 class ArrayOrderedArgsGenerator<T>(
 	componentFactoryContainer: ComponentFactoryContainer,
-	private val values: Array<T>
-) : BaseSemiOrderedArgsGenerator<T>(componentFactoryContainer, values.size), OrderedArgsGenerator<T> {
+	seedBaseOffset: Int,
+	private val values: Array<T>,
+) : BaseSemiOrderedArgsGenerator<T>(componentFactoryContainer, seedBaseOffset, values.size), OrderedArgsGenerator<T> {
 
 	override fun generateOneAfterChecks(offset: Int): T {
 		val index = determineStartingIndex(0, size, offset, 1)

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/BaseSemiOrderedArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/BaseSemiOrderedArgsGenerator.kt
@@ -2,8 +2,8 @@ package com.tegonal.variist.generators.impl
 
 import com.tegonal.variist.config.ComponentFactoryContainer
 import com.tegonal.variist.config.ComponentFactoryContainerProvider
+import com.tegonal.variist.generators.CoreSemiOrderedArgsGenerator
 import com.tegonal.variist.generators.OrderedArgsGenerator
-import com.tegonal.variist.generators.SemiOrderedArgsGenerator
 import com.tegonal.variist.utils.BigInt
 import com.tegonal.variist.utils.impl.checkIsPositive
 
@@ -15,21 +15,40 @@ import com.tegonal.variist.utils.impl.checkIsPositive
  */
 abstract class BaseSemiOrderedArgsGenerator<T>(
 	final override val componentFactoryContainer: ComponentFactoryContainer,
-	final override val size: Int
-) : SemiOrderedArgsGenerator<T>, ComponentFactoryContainerProvider {
+	final override val seedBaseOffset: Int,
+	final override val size: Int,
+) : CoreSemiOrderedArgsGenerator<T>, ComponentFactoryContainerProvider {
 
-	constructor(componentFactoryContainer: ComponentFactoryContainer, size: Long) : this(
+	constructor(arbGenerator: CoreSemiOrderedArgsGenerator<*>, size: Int) : this(
+		arbGenerator.componentFactoryContainer,
+		arbGenerator.seedBaseOffset + 1,
+		size
+	)
+
+	constructor(arbGenerator: CoreSemiOrderedArgsGenerator<*>, size: Long) : this(
+		arbGenerator.componentFactoryContainer,
+		arbGenerator.seedBaseOffset + 1,
+		size
+	)
+
+	constructor(
+		componentFactoryContainer: ComponentFactoryContainer,
+		seedBaseOffset: Int,
+		size: Long
+	) : this(
 		componentFactoryContainer,
+		seedBaseOffset,
 		size.toInt().also {
 			check(it.toLong() == size) {
 				// toInt() overflowed
 				"${OrderedArgsGenerator::class.simpleName}.${OrderedArgsGenerator<*>::size.name} only supports Int, the given size ($size) is bigger"
 			}
-		}
+		},
 	)
 
-	constructor(componentFactoryContainer: ComponentFactoryContainer, size: BigInt) : this(
+	constructor(componentFactoryContainer: ComponentFactoryContainer, seedBaseOffset: Int, size: BigInt) : this(
 		componentFactoryContainer,
+		seedBaseOffset,
 		size.toInt().also {
 			check(size.bitLength() <= 31) {
 				"${OrderedArgsGenerator::class.simpleName}.${OrderedArgsGenerator<*>::size.name} only supports Int, the given size ($size) is bigger"

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/BaseSemiOrderedArgsGeneratorTransformer.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/BaseSemiOrderedArgsGeneratorTransformer.kt
@@ -1,7 +1,7 @@
 package com.tegonal.variist.generators.impl
 
-import com.tegonal.variist.config._components
 import com.tegonal.variist.generators.SemiOrderedArgsGenerator
+import com.tegonal.variist.generators._core
 
 /**
  * !! No backward compatibility guarantees !!
@@ -12,7 +12,7 @@ import com.tegonal.variist.generators.SemiOrderedArgsGenerator
 abstract class BaseSemiOrderedArgsGeneratorTransformer<T, R>(
 	private val baseGenerator: SemiOrderedArgsGenerator<T>,
 	private val transform: (Sequence<T>) -> Sequence<R>
-) : BaseSemiOrderedArgsGenerator<R>(baseGenerator._components, baseGenerator.size) {
+) : BaseSemiOrderedArgsGenerator<R>(baseGenerator._core, baseGenerator.size) {
 
 	override fun generateAfterChecks(offset: Int): Sequence<R> = baseGenerator.generate(offset).let(transform)
 }

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/ListOrderedArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/ListOrderedArgsGenerator.kt
@@ -15,8 +15,9 @@ import com.tegonal.variist.utils.repeatForever
  */
 class ListOrderedArgsGenerator<T>(
 	componentFactoryContainer: ComponentFactoryContainer,
+	seedBaseOffset: Int,
 	private val values: List<T>
-) : BaseSemiOrderedArgsGenerator<T>(componentFactoryContainer, values.size), OrderedArgsGenerator<T> {
+) : BaseSemiOrderedArgsGenerator<T>(componentFactoryContainer, seedBaseOffset, values.size), OrderedArgsGenerator<T> {
 
 	override fun generateOneAfterChecks(offset: Int): T {
 		val index = determineStartingIndex(0, size, offset, 1)

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/RandomAccessOrderedArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/RandomAccessOrderedArgsGenerator.kt
@@ -15,9 +15,10 @@ import com.tegonal.variist.utils.impl.determineStartingIndex
  */
 class RandomAccessOrderedArgsGenerator<T>(
 	componentFactoryContainer: ComponentFactoryContainer,
+	seedBaseOffset: Int,
 	size: Int,
 	private val elementAt: (index: Int) -> T
-) : BaseSemiOrderedArgsGenerator<T>(componentFactoryContainer, size), OrderedArgsGenerator<T> {
+) : BaseSemiOrderedArgsGenerator<T>(componentFactoryContainer, seedBaseOffset, size), OrderedArgsGenerator<T> {
 
 	override fun generateOneAfterChecks(offset: Int): T {
 		val index = determineStartingIndex(0, size, offset, 1)

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/SemiOrderedFlatZipArbArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/SemiOrderedFlatZipArbArgsGenerator.kt
@@ -1,10 +1,6 @@
 package com.tegonal.variist.generators.impl
 
-import com.tegonal.variist.config._components
-import com.tegonal.variist.config.arb
-import com.tegonal.variist.generators.ArbArgsGenerator
-import com.tegonal.variist.generators.ArbExtensionPoint
-import com.tegonal.variist.generators.SemiOrderedArgsGenerator
+import com.tegonal.variist.generators.*
 
 /**
  * !! No backward compatibility guarantees !!
@@ -17,13 +13,15 @@ class SemiOrderedFlatZipArbArgsGenerator<A1, A2, R>(
 	private val otherFactory: ArbExtensionPoint.(A1) -> ArbArgsGenerator<A2>,
 	private val amount: Int,
 	private val transform: (A1, A2) -> R
-) : BaseSemiOrderedArgsGenerator<R>(semiOrderedArgsGenerator._components, semiOrderedArgsGenerator.size * amount) {
+) : BaseSemiOrderedArgsGenerator<R>(semiOrderedArgsGenerator._core, semiOrderedArgsGenerator.size * amount) {
 
 	override fun generateOneAfterChecks(offset: Int): R {
 		val orderedOffset = offset / amount
 		val transformationOffset = offset % amount
 		val a1 = semiOrderedArgsGenerator.generateOne(orderedOffset)
-		val a2 = componentFactoryContainer.arb.otherFactory(a1).generate(seedOffset = 0)
+		// note, no need to do generate(offset + seedBaseOffset) here because _core.arb already passes the
+		// seedBaseOffset to the generated ArbArgsGenerator
+		val a2 = _core.arb.otherFactory(a1).generate(seedOffset = 0)
 			.drop(transformationOffset).first()
 		return transform(a1, a2)
 	}
@@ -33,7 +31,7 @@ class SemiOrderedFlatZipArbArgsGenerator<A1, A2, R>(
 		val orderedOffset = offset / amount
 		val transformationOffset = offset % amount
 		return semiOrderedArgsGenerator.flatMapIndexedInternal { index, a1: A1 ->
-			componentFactoryContainer.arb.otherFactory(a1).generate(seedOffset = index)
+			_core.arb.otherFactory(a1).generate(seedOffset = index)
 				.take(amount).drop(transformationOffset).map { a2 ->
 					transform(a1, a2)
 				}

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/SemiOrderedZipArbArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/SemiOrderedZipArbArgsGenerator.kt
@@ -2,7 +2,7 @@ package com.tegonal.variist.generators.impl
 
 import com.tegonal.variist.generators.ArbArgsGenerator
 import com.tegonal.variist.generators.SemiOrderedArgsGenerator
-import com.tegonal.variist.config._components
+import com.tegonal.variist.generators._core
 
 /**
  * !! No backward compatibility guarantees !!
@@ -14,8 +14,17 @@ class SemiOrderedZipArbArgsGenerator<A1, A2, R>(
 	private val semiOrderedArgsGenerator: SemiOrderedArgsGenerator<A1>,
 	private val arbArgsGenerator: ArbArgsGenerator<A2>,
 	private val transform: (A1, A2) -> R
-) : BaseSemiOrderedArgsGenerator<R>(semiOrderedArgsGenerator._components, semiOrderedArgsGenerator.size) {
+) : BaseSemiOrderedArgsGenerator<R>(semiOrderedArgsGenerator._core, semiOrderedArgsGenerator.size) {
 
 	override fun generateAfterChecks(offset: Int): Sequence<R> =
-		zipForever(semiOrderedArgsGenerator.generate(offset), arbArgsGenerator.generate(), transform)
+		zipForever(
+			semiOrderedArgsGenerator.generate(offset),
+			// +seedBaseOffset because we want different values if a similar ArbArgsGenerator is used in multiple
+			// SemiOrderedArgsGenerators (e.g. combined multiple times) -- for instance:
+			// orderef.of(1).zip(arb.of('a','b')).zip(arb.of('a','b'))
+			// the two arb should not generate exactly the same sequence otherwise we will see only the values:
+			// (1, 'a','a'), (1, 'b','b')
+			arbArgsGenerator.generate(offset + seedBaseOffset),
+			transform
+		)
 }

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/generatorExtensionPoints.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/generatorExtensionPoints.kt
@@ -2,12 +2,39 @@ package com.tegonal.variist.generators.impl
 
 import com.tegonal.variist.config.ComponentFactoryContainer
 import com.tegonal.variist.config.ComponentFactoryContainerProvider
-import com.tegonal.variist.config.arb
-import com.tegonal.variist.config.ordered
-import com.tegonal.variist.config.semiOrdered
 import com.tegonal.variist.generators.ArbExtensionPoint
+import com.tegonal.variist.generators.GeneratorExtensionPoint
 import com.tegonal.variist.generators.OrderedExtensionPoint
 import com.tegonal.variist.generators.SemiOrderedExtensionPoint
+
+abstract class BaseGeneratorExtensionPoint(
+	override val componentFactoryContainer: ComponentFactoryContainer,
+	/**
+	 * Will be added to [com.tegonal.variist.config.VariistConfig.seed] for generators consisting of an arbitrary part.
+	 *
+	 * Is allowed to be negative.
+	 */
+	override val seedBaseOffset: Int,
+) : GeneratorExtensionPoint, ComponentFactoryContainerProvider {
+	override val arb: ArbExtensionPoint
+		get() = DefaultArbExtensionPoint(
+			componentFactoryContainer,
+			// expected that this can overflow in the worst case
+			seedBaseOffset + 1
+		)
+	override val ordered: OrderedExtensionPoint
+		get() = DefaultOrderedExtensionPoint(
+			componentFactoryContainer,
+			// expected that this can overflow in the worst case
+			seedBaseOffset + 1
+		)
+	override val semiOrdered: SemiOrderedExtensionPoint
+		get() = DefaultSemiOrderedExtensionPoint(
+			componentFactoryContainer,
+			// expected that this can overflow in the worst case
+			seedBaseOffset + 1
+		)
+}
 
 /**
  * !! No backward compatibility guarantees !!
@@ -16,12 +43,9 @@ import com.tegonal.variist.generators.SemiOrderedExtensionPoint
  * @since 2.0.0
  */
 class DefaultOrderedExtensionPoint(
-	override val componentFactoryContainer: ComponentFactoryContainer
-) : OrderedExtensionPoint, ComponentFactoryContainerProvider {
-	override val arb: ArbExtensionPoint get() = componentFactoryContainer.arb
-	override val ordered: OrderedExtensionPoint get() = componentFactoryContainer.ordered
-	override val semiOrdered: SemiOrderedExtensionPoint get() = componentFactoryContainer.semiOrdered
-}
+	componentFactoryContainer: ComponentFactoryContainer,
+	seedBaseOffset: Int,
+) : BaseGeneratorExtensionPoint(componentFactoryContainer, seedBaseOffset), OrderedExtensionPoint
 
 /**
  * !! No backward compatibility guarantees !!
@@ -30,12 +54,9 @@ class DefaultOrderedExtensionPoint(
  * @since 2.0.0
  */
 class DefaultSemiOrderedExtensionPoint(
-	override val componentFactoryContainer: ComponentFactoryContainer
-) : SemiOrderedExtensionPoint, ComponentFactoryContainerProvider {
-	override val arb: ArbExtensionPoint get() = componentFactoryContainer.arb
-	override val ordered: OrderedExtensionPoint get() = componentFactoryContainer.ordered
-	override val semiOrdered: SemiOrderedExtensionPoint get() = componentFactoryContainer.semiOrdered
-}
+	componentFactoryContainer: ComponentFactoryContainer,
+	seedBaseOffset: Int,
+) : BaseGeneratorExtensionPoint(componentFactoryContainer, seedBaseOffset), SemiOrderedExtensionPoint
 
 /**
  * !! No backward compatibility guarantees !!
@@ -44,21 +65,6 @@ class DefaultSemiOrderedExtensionPoint(
  * @since 2.0.0
  */
 class DefaultArbExtensionPoint(
-	override val componentFactoryContainer: ComponentFactoryContainer,
-	/**
-	 * Will be added to [com.tegonal.variist.config.VariistConfig.seed].
-	 *
-	 * Is allowed to be negative.
-	 */
-	override val seedBaseOffset: Int,
-) : ArbExtensionPoint, ComponentFactoryContainerProvider {
-
-	override val arb: ArbExtensionPoint
-		get() = DefaultArbExtensionPoint(
-			componentFactoryContainer,
-			// expected that this can overflow in the worst case
-			seedBaseOffset + 1
-		)
-	override val ordered: OrderedExtensionPoint get() = componentFactoryContainer.ordered
-	override val semiOrdered: SemiOrderedExtensionPoint get() = componentFactoryContainer.semiOrdered
-}
+	componentFactoryContainer: ComponentFactoryContainer,
+	seedBaseOffset: Int,
+) : BaseGeneratorExtensionPoint(componentFactoryContainer, seedBaseOffset), ArbExtensionPoint

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/orderedArgsGeneratorConcatenators.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/orderedArgsGeneratorConcatenators.kt
@@ -1,8 +1,8 @@
 package com.tegonal.variist.generators.impl
 
-import com.tegonal.variist.config._components
 import com.tegonal.variist.generators.OrderedArgsGenerator
 import com.tegonal.variist.generators.SemiOrderedArgsGenerator
+import com.tegonal.variist.generators._core
 
 /**
  * !! No backward compatibility guarantees !!
@@ -17,7 +17,7 @@ class OrderedArgsGeneratorConcatenator<T>(
 	// note, we don't (and cannot) check that a1Generator and a2Generator use the same ComponentContainer,
 	// should you run into weird behaviour (such as one generator uses seed X and the other seed Y) then most likely
 	// someone used two different initial factories
-	a1Generator._components,
+	a1Generator._core,
 	a1Generator.size.toLong() + a2Generator.size.toLong()
 ), OrderedArgsGenerator<T> {
 
@@ -48,7 +48,7 @@ class SemiOrderedArgsGeneratorConcatenator<T>(
 	// note, we don't (and cannot) check that a1Generator and a2Generator use the same ComponentContainer,
 	// should you run into weird behaviour (such as one generator uses seed X and the other seed Y) then most likely
 	// someone used two different initial factories
-	a1Generator._components,
+	a1Generator._core,
 	a1Generator.size.toLong() + a2Generator.size.toLong()
 ) {
 

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/orderedCartesianProductArgsGenerators.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/orderedCartesianProductArgsGenerators.kt
@@ -3,6 +3,7 @@ package com.tegonal.variist.generators.impl
 import com.tegonal.variist.config._components
 import com.tegonal.variist.generators.OrderedArgsGenerator
 import com.tegonal.variist.generators.SemiOrderedArgsGenerator
+import com.tegonal.variist.generators._core
 
 /**
  * !! No backward compatibility guarantees !!
@@ -43,6 +44,7 @@ abstract class CartesianProductArgsGenerator<A1, A2, R>(
 	// should you run into weird behaviour (such as one generator uses seed X and the other seed Y) then most likely
 	// someone used two different initial factories
 	a1Generator._components,
+	a1Generator._core.seedBaseOffset + a2Generator._core.seedBaseOffset + 1,
 	a1Generator.size.toLong() * a2Generator.size.toLong()
 ) {
 	// Note calculating the lcm doesn't bring much in speed: up to -10% if less than 3 values, up to 13% for > 12 values

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/orderedNumberGenerators.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/orderedNumberGenerators.kt
@@ -4,11 +4,7 @@ import com.tegonal.variist.config.ComponentFactoryContainer
 import com.tegonal.variist.generators.OrderedArgsGenerator
 import com.tegonal.variist.generators.map
 import com.tegonal.variist.utils.BigInt
-import com.tegonal.variist.utils.impl.BigIntFromUntilRepeatingIterator
-import com.tegonal.variist.utils.impl.IntFromUntilRepeatingIterator
-import com.tegonal.variist.utils.impl.LongFromUntilRepeatingIterator
-import com.tegonal.variist.utils.impl.checkRangeNumbers
-import com.tegonal.variist.utils.impl.determineStartingIndex
+import com.tegonal.variist.utils.impl.*
 import com.tegonal.variist.utils.toBigInt
 
 /**
@@ -19,11 +15,13 @@ import com.tegonal.variist.utils.toBigInt
  */
 class IntFromUntilOrderedArgsGenerator(
 	componentFactoryContainer: ComponentFactoryContainer,
+	seedBaseOffset: Int,
 	private val from: Int,
 	private val toExclusive: Int,
 	private val step: Int,
 ) : BaseSemiOrderedArgsGenerator<Int>(
 	componentFactoryContainer,
+	seedBaseOffset,
 	run {
 		// we first check the numbers before calculating the size as the size would be wrong
 		// if the invariants are not given
@@ -54,11 +52,13 @@ class IntFromUntilOrderedArgsGenerator(
  */
 class LongFromUntilOrderedArgsGenerator(
 	componentFactoryContainer: ComponentFactoryContainer,
+	seedBaseOffset: Int,
 	private val from: Long,
 	private val toExclusive: Long,
 	private val step: Long,
 ) : BaseSemiOrderedArgsGenerator<Long>(
 	componentFactoryContainer,
+	seedBaseOffset,
 	run {
 		// we first check the numbers before calculating the size as the size would be wrong
 		// if the invariants are not given
@@ -89,11 +89,13 @@ class LongFromUntilOrderedArgsGenerator(
  */
 class BigIntFromUntilOrderedArgsGenerator(
 	componentFactoryContainer: ComponentFactoryContainer,
+	seedBaseOffset: Int,
 	private val from: BigInt,
 	private val toExclusive: BigInt,
 	private val step: BigInt,
 ) : BaseSemiOrderedArgsGenerator<BigInt>(
 	componentFactoryContainer,
+	seedBaseOffset,
 	run {
 		// we first check the numbers before calculating the size as the size would be wrong
 		// if the invariants are not given
@@ -158,6 +160,7 @@ private inline fun <NumberT> calculatedRangeSizeToArgsGeneratorSize(
 @Suppress("FunctionName")
 fun IntFromToOrderedArgsGenerator(
 	componentFactoryContainer: ComponentFactoryContainer,
+	seedBaseOffset: Int,
 	from: Int,
 	toInclusive: Int,
 	step: Int,
@@ -166,11 +169,12 @@ fun IntFromToOrderedArgsGenerator(
 		//TODO 2.5.0 bench what is better (speed vs. memory), this approach or if we would shift the range if possible?
 		LongFromUntilOrderedArgsGenerator(
 			componentFactoryContainer,
+			seedBaseOffset,
 			from.toLong(),
 			toInclusive.toLong() + 1,
 			step.toLong()
 		).map { it.toInt() }
-	} else IntFromUntilOrderedArgsGenerator(componentFactoryContainer, from, toInclusive + 1, step)
+	} else IntFromUntilOrderedArgsGenerator(componentFactoryContainer, seedBaseOffset, from, toInclusive + 1, step)
 
 /**
  * !! No backward compatibility guarantees !!
@@ -181,6 +185,7 @@ fun IntFromToOrderedArgsGenerator(
 @Suppress("FunctionName")
 fun LongFromToOrderedArgsGenerator(
 	componentFactoryContainer: ComponentFactoryContainer,
+	seedBaseOffset: Int,
 	from: Long,
 	toInclusive: Long,
 	step: Long,
@@ -189,8 +194,9 @@ fun LongFromToOrderedArgsGenerator(
 		//TODO 2.5.0 bench what is better (speed vs. memory), this approach or if we would shift the range
 		BigIntFromUntilOrderedArgsGenerator(
 			componentFactoryContainer,
+			seedBaseOffset,
 			from.toBigInt(),
 			toInclusive.toBigInt() + BigInt.ONE,
 			step.toBigInt()
 		).map { it.toLong() }
-	} else LongFromUntilOrderedArgsGenerator(componentFactoryContainer, from, toInclusive + 1, step)
+	} else LongFromUntilOrderedArgsGenerator(componentFactoryContainer, seedBaseOffset, from, toInclusive + 1, step)

--- a/src/main/kotlin/com/tegonal/variist/generators/orderedFromArray.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/orderedFromArray.kt
@@ -10,7 +10,7 @@ import com.tegonal.variist.generators.impl.RandomAccessOrderedArgsGenerator
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromArray(args: ByteArray): OrderedArgsGenerator<Byte> =
-	RandomAccessOrderedArgsGenerator(_components, args.size) { args[it] }
+	RandomAccessOrderedArgsGenerator(_components, seedBaseOffset, args.size) { args[it] }
 
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
@@ -18,7 +18,7 @@ fun OrderedExtensionPoint.fromArray(args: ByteArray): OrderedArgsGenerator<Byte>
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromArray(args: CharArray): OrderedArgsGenerator<Char> =
-	RandomAccessOrderedArgsGenerator(_components, args.size) { args[it] }
+	RandomAccessOrderedArgsGenerator(_components, seedBaseOffset, args.size) { args[it] }
 
 
 /**
@@ -27,7 +27,7 @@ fun OrderedExtensionPoint.fromArray(args: CharArray): OrderedArgsGenerator<Char>
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromArray(args: ShortArray): OrderedArgsGenerator<Short> =
-	RandomAccessOrderedArgsGenerator(_components, args.size) { args[it] }
+	RandomAccessOrderedArgsGenerator(_components, seedBaseOffset, args.size) { args[it] }
 
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
@@ -35,7 +35,7 @@ fun OrderedExtensionPoint.fromArray(args: ShortArray): OrderedArgsGenerator<Shor
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromArray(args: IntArray): OrderedArgsGenerator<Int> =
-	RandomAccessOrderedArgsGenerator(_components, args.size) { args[it] }
+	RandomAccessOrderedArgsGenerator(_components, seedBaseOffset, args.size) { args[it] }
 
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
@@ -43,7 +43,7 @@ fun OrderedExtensionPoint.fromArray(args: IntArray): OrderedArgsGenerator<Int> =
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromArray(args: LongArray): OrderedArgsGenerator<Long> =
-	RandomAccessOrderedArgsGenerator(_components, args.size) { args[it] }
+	RandomAccessOrderedArgsGenerator(_components, seedBaseOffset, args.size) { args[it] }
 
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
@@ -51,7 +51,7 @@ fun OrderedExtensionPoint.fromArray(args: LongArray): OrderedArgsGenerator<Long>
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromArray(args: FloatArray): OrderedArgsGenerator<Float> =
-	RandomAccessOrderedArgsGenerator(_components, args.size) { args[it] }
+	RandomAccessOrderedArgsGenerator(_components, seedBaseOffset, args.size) { args[it] }
 
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
@@ -59,7 +59,7 @@ fun OrderedExtensionPoint.fromArray(args: FloatArray): OrderedArgsGenerator<Floa
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromArray(args: DoubleArray): OrderedArgsGenerator<Double> =
-	RandomAccessOrderedArgsGenerator(_components, args.size) { args[it] }
+	RandomAccessOrderedArgsGenerator(_components, seedBaseOffset, args.size) { args[it] }
 
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
@@ -67,7 +67,7 @@ fun OrderedExtensionPoint.fromArray(args: DoubleArray): OrderedArgsGenerator<Dou
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromArray(args: BooleanArray): OrderedArgsGenerator<Boolean> =
-	RandomAccessOrderedArgsGenerator(_components, args.size) { args[it] }
+	RandomAccessOrderedArgsGenerator(_components, seedBaseOffset, args.size) { args[it] }
 
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
@@ -75,4 +75,4 @@ fun OrderedExtensionPoint.fromArray(args: BooleanArray): OrderedArgsGenerator<Bo
  * @since 2.0.0
  */
 fun <T> OrderedExtensionPoint.fromArray(args: Array<out T>): OrderedArgsGenerator<T> =
-	ArrayOrderedArgsGenerator(_components, args)
+	ArrayOrderedArgsGenerator(_components, seedBaseOffset, args)

--- a/src/main/kotlin/com/tegonal/variist/generators/orderedFromEnum.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/orderedFromEnum.kt
@@ -11,4 +11,4 @@ import com.tegonal.variist.generators.impl.ArrayOrderedArgsGenerator
  * @since 2.0.0
  */
 inline fun <reified E : Enum<E>> OrderedExtensionPoint.fromEnum(): OrderedArgsGenerator<E> =
-	ArrayOrderedArgsGenerator(_components, enumValues<E>())
+	ArrayOrderedArgsGenerator(_components, seedBaseOffset, enumValues<E>())

--- a/src/main/kotlin/com/tegonal/variist/generators/orderedFromList.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/orderedFromList.kt
@@ -9,4 +9,4 @@ import com.tegonal.variist.generators.impl.ListOrderedArgsGenerator
  * @since 2.0.0
  */
 fun <T> OrderedExtensionPoint.fromList(args: List<T>): OrderedArgsGenerator<T> =
-	ListOrderedArgsGenerator(_components, args)
+	ListOrderedArgsGenerator(_components, seedBaseOffset, args)

--- a/src/main/kotlin/com/tegonal/variist/generators/orderedFromProgression.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/orderedFromProgression.kt
@@ -11,8 +11,13 @@ import com.tegonal.variist.generators.impl.LongFromToOrderedArgsGenerator
  */
 fun OrderedExtensionPoint.fromProgression(progression: CharProgression): OrderedArgsGenerator<Char> =
 	if (progression.step > 0) {
-		IntFromToOrderedArgsGenerator(_components, progression.first.code, progression.last.code, progression.step)
-			.map { it.toChar() }
+		IntFromToOrderedArgsGenerator(
+			_components,
+			seedBaseOffset,
+			progression.first.code,
+			progression.last.code,
+			progression.step
+		).map { it.toChar() }
 	}
 	//TODO 2.2.0 no longer needed once we support minus steps in the iterator
 	else fromList(progression.toList())
@@ -24,7 +29,13 @@ fun OrderedExtensionPoint.fromProgression(progression: CharProgression): Ordered
  */
 fun OrderedExtensionPoint.fromProgression(progression: IntProgression): OrderedArgsGenerator<Int> =
 	if (progression.step > 0) {
-		IntFromToOrderedArgsGenerator(_components, progression.first, progression.last, progression.step)
+		IntFromToOrderedArgsGenerator(
+			_components,
+			seedBaseOffset,
+			progression.first,
+			progression.last,
+			progression.step
+		)
 	}
 	//TODO 2.2.0 no longer needed once we support minus steps in the iterator
 	else fromList(progression.toList())
@@ -36,7 +47,13 @@ fun OrderedExtensionPoint.fromProgression(progression: IntProgression): OrderedA
  */
 fun OrderedExtensionPoint.fromProgression(progression: LongProgression): OrderedArgsGenerator<Long> =
 	if (progression.step > 0) {
-		LongFromToOrderedArgsGenerator(_components, progression.first, progression.last, progression.step)
+		LongFromToOrderedArgsGenerator(
+			_components,
+			seedBaseOffset,
+			progression.first,
+			progression.last,
+			progression.step
+		)
 	}
 	//TODO 2.2.0 no longer needed once we support minus steps in the iterator
 	else fromList(progression.toList())

--- a/src/main/kotlin/com/tegonal/variist/generators/orderedNumber.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/orderedNumber.kt
@@ -12,7 +12,9 @@ import com.tegonal.variist.utils.BigInt
 fun OrderedExtensionPoint.intFromUntil(
 	from: Int,
 	toExclusive: Int,
-): OrderedArgsGenerator<Int> = IntFromUntilOrderedArgsGenerator(_components, from, toExclusive, step = 1)
+): OrderedArgsGenerator<Int> = IntFromUntilOrderedArgsGenerator(
+	_components, seedBaseOffset, from, toExclusive, step = 1
+)
 
 /**
  * Returns an [OrderedArgsGenerator]which generates [Long]s ranging [from] (inclusive) until [toExclusive].
@@ -22,7 +24,9 @@ fun OrderedExtensionPoint.intFromUntil(
 fun OrderedExtensionPoint.longFromUntil(
 	from: Long,
 	toExclusive: Long,
-): OrderedArgsGenerator<Long> = LongFromUntilOrderedArgsGenerator(_components, from, toExclusive, step = 1)
+): OrderedArgsGenerator<Long> = LongFromUntilOrderedArgsGenerator(
+	_components, seedBaseOffset, from, toExclusive, step = 1
+)
 
 /**
  * Returns an [OrderedArgsGenerator] which generates [BigInt]s ranging [from] (inclusive) until [toExclusive].
@@ -32,7 +36,9 @@ fun OrderedExtensionPoint.longFromUntil(
 fun OrderedExtensionPoint.bigIntFromUntil(
 	from: BigInt,
 	toExclusive: BigInt,
-): OrderedArgsGenerator<BigInt> = BigIntFromUntilOrderedArgsGenerator(_components, from, toExclusive, step = BigInt.ONE)
+): OrderedArgsGenerator<BigInt> = BigIntFromUntilOrderedArgsGenerator(
+	_components, seedBaseOffset, from, toExclusive, step = BigInt.ONE
+)
 
 
 /**
@@ -43,7 +49,9 @@ fun OrderedExtensionPoint.bigIntFromUntil(
 fun OrderedExtensionPoint.intFromTo(
 	from: Int,
 	toInclusive: Int,
-): OrderedArgsGenerator<Int> = IntFromToOrderedArgsGenerator(_components, from, toInclusive, step = 1)
+): OrderedArgsGenerator<Int> = IntFromToOrderedArgsGenerator(
+	_components, seedBaseOffset, from, toInclusive, step = 1
+)
 
 /**
  * Returns an [OrderedArgsGenerator] which generates [Long]s ranging [from] (inclusive) to [toInclusive].
@@ -53,7 +61,9 @@ fun OrderedExtensionPoint.intFromTo(
 fun OrderedExtensionPoint.longFromTo(
 	from: Long,
 	toInclusive: Long,
-): OrderedArgsGenerator<Long> = LongFromToOrderedArgsGenerator(_components, from, toInclusive, step = 1L)
+): OrderedArgsGenerator<Long> = LongFromToOrderedArgsGenerator(
+	_components, seedBaseOffset, from, toInclusive, step = 1L
+)
 
 /**
  * Returns an [OrderedArgsGenerator] which generates [BigInt]s ranging [from] (inclusive) to [toInclusive].
@@ -63,5 +73,6 @@ fun OrderedExtensionPoint.longFromTo(
 fun OrderedExtensionPoint.bigIntFromTo(
 	from: BigInt,
 	toInclusive: BigInt,
-): OrderedArgsGenerator<BigInt> =
-	BigIntFromUntilOrderedArgsGenerator(_components, from, toInclusive + BigInt.ONE, step = BigInt.ONE)
+): OrderedArgsGenerator<BigInt> = BigIntFromUntilOrderedArgsGenerator(
+	_components, seedBaseOffset, from, toInclusive + BigInt.ONE, step = BigInt.ONE
+)

--- a/src/main/kotlin/com/tegonal/variist/generators/orderedOf.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/orderedOf.kt
@@ -10,4 +10,4 @@ import com.tegonal.variist.generators.impl.ArrayOrderedArgsGenerator
  */
 // note: not `arg: T, vararg args: T` on purpose for performance reasons, we have a check on size
 fun <T> OrderedExtensionPoint.of(vararg args: T): OrderedArgsGenerator<T> =
-	ArrayOrderedArgsGenerator(_components, args)
+	ArrayOrderedArgsGenerator(_components, seedBaseOffset, args)

--- a/src/test/kotlin/com/tegonal/variist/generators/ArbDateLikeTest.kt
+++ b/src/test/kotlin/com/tegonal/variist/generators/ArbDateLikeTest.kt
@@ -1,6 +1,7 @@
 package com.tegonal.variist.generators
 
 import ch.tutteli.kbox.Tuple
+import java.time.LocalTime
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 
@@ -9,7 +10,9 @@ class ArbDateLikeTest : AbstractArbArgsGeneratorTest<Any>() {
 	override fun createGenerators(modifiedArb: ArbExtensionPoint) =
 		ZonedDateTime.now().truncatedTo(ChronoUnit.HOURS).let { nowZonedDateTime ->
 			val nowLocalDateTime = nowZonedDateTime.toLocalDateTime()
-			val nowLocalTime = nowZonedDateTime.toLocalTime()
+			val nowLocalTime = nowZonedDateTime.toLocalTime().let {
+				if (it.plusHours(2) > LocalTime.of(0, 0)) LocalTime.of(21, 0) else it
+			}
 			val nowLocalDate = nowZonedDateTime.toLocalDate()
 			val nowOffsetDateTime = nowZonedDateTime.toOffsetDateTime()
 			sequenceOf(

--- a/src/test/kotlin/com/tegonal/variist/generators/SemiOrderedWithArbCombineAllTest.kt
+++ b/src/test/kotlin/com/tegonal/variist/generators/SemiOrderedWithArbCombineAllTest.kt
@@ -9,6 +9,11 @@ import org.junit.jupiter.api.TestFactory
 class SemiOrderedWithArbCombineAllTest : AbstractOrderedArgsGeneratorWithoutAnnotationsTest() {
 	val a1s = listOf(1, 2)
 	val a2s = listOf('a', 'b', 'c')
+
+	// implementation detail, since we do seedBaseOffset+1 in BaseSemiOrderedArgsGenerator the a2s are shifted
+	val a2sZipped = listOf(Tuple('a', 'b'), Tuple('b', 'c'), Tuple('c', 'a'))
+	val a2sZipped2 = listOf(Tuple('a', 'b', 'c'), Tuple('b', 'c', 'a'), Tuple('c', 'a', 'b'))
+
 	val generator: SemiOrderedArgsGenerator<Int> = customComponentFactoryContainer.ordered.fromList(a1s)
 	val randomGenerator = PseudoArbArgsGenerator(a2s)
 
@@ -22,7 +27,7 @@ class SemiOrderedWithArbCombineAllTest : AbstractOrderedArgsGeneratorWithoutAnno
 			"combine with 2 random",
 			Tuple(generator, randomGenerator, randomGenerator).combineAll()
 				.map { (a1, a2, a3) -> a1 to (a2 to a3) },
-			a1s.zip(a2s.map { it to it })
+			a1s.zip(a2sZipped)
 		),
 		Tuple(
 			"combine with 3 random",
@@ -30,7 +35,7 @@ class SemiOrderedWithArbCombineAllTest : AbstractOrderedArgsGeneratorWithoutAnno
 				.map { (a1, a2, a3, a4) ->
 					a1 to Triple(a2, a3, a4)
 				},
-			a1s.zip(a2s.map { Triple(it, it, it) })
+			a1s.zip(a2sZipped2)
 		)
 	)
 
@@ -45,7 +50,7 @@ class SemiOrderedWithArbCombineAllTest : AbstractOrderedArgsGeneratorWithoutAnno
 				"combine with 2 random",
 				Tuple(generator, randomGenerator, randomGenerator).combineAll()
 					.map { (a1, a2, a3) -> a1 to (a2 to a3) },
-				a1s.flatMap { a1 -> a2s.map { a2 -> a1 to (a2 to a2) } }
+				a1s.flatMap { a1 -> a2sZipped.map { a1 to it } }
 			),
 			Tuple(
 				"combine with 3 random",
@@ -53,7 +58,7 @@ class SemiOrderedWithArbCombineAllTest : AbstractOrderedArgsGeneratorWithoutAnno
 					.map { (a1, a2, a3, a4) ->
 						a1 to Triple(a2, a3, a4)
 					},
-				a1s.flatMap { a1 -> a2s.map { a2 -> a1 to Triple(a2, a2, a2) } }
+				a1s.flatMap { a1 -> a2sZipped2.map { a1 to it } }
 			)
 		)
 

--- a/src/test/kotlin/com/tegonal/variist/generators/SemiOrderedZipArbTest.kt
+++ b/src/test/kotlin/com/tegonal/variist/generators/SemiOrderedZipArbTest.kt
@@ -9,6 +9,11 @@ import org.junit.jupiter.api.TestFactory
 class SemiOrderedZipArbTest : AbstractOrderedArgsGeneratorWithoutAnnotationsTest() {
 	val a1s = listOf(1, 2)
 	val a2s = listOf('a', 'b', 'c')
+
+	// implementation detail, since we do seedBaseOffset+1 in BaseSemiOrderedArgsGenerator the a2s are shifted
+	val a2sZipped = listOf(Tuple('a', 'b'), Tuple('b', 'c'), Tuple('c', 'a'))
+	val a2sZipped2 = listOf(Tuple('a', 'b', 'c'), Tuple('b', 'c', 'a'), Tuple('c', 'a', 'b'))
+
 	val generator = customComponentFactoryContainer.ordered.fromList(a1s)
 	val randomGenerator = PseudoArbArgsGenerator(a2s)
 
@@ -26,15 +31,15 @@ class SemiOrderedZipArbTest : AbstractOrderedArgsGeneratorWithoutAnnotationsTest
 				.zip(randomGenerator) { pair, a3 ->
 					pair.mapSecond { it to a3 }
 				},
-			a1s.zip(a2s.map { it to it })
+			a1s.zip(a2sZipped)
 		),
 		Tuple(
-			"combine with 3 random",
+			"zip with 3 random",
 			generator.zip(randomGenerator).zip(randomGenerator)
 				.zip(randomGenerator) { (a1, a2, a3), a4 ->
 					a1 to Triple(a2, a3, a4)
 				},
-			a1s.zip(a2s.map { Triple(it, it, it) })
+			a1s.zip(a2sZipped2)
 		),
 		Tuple(
 			"zipDependent",
@@ -42,7 +47,7 @@ class SemiOrderedZipArbTest : AbstractOrderedArgsGeneratorWithoutAnnotationsTest
 			// zip is only correct because for most tests we don't take more than generator.size
 			// see createGeneratorsAllPossibleCombinations where we need to use flatMap
 			// also note that we can zip since we know that zipDependent increases the seedOffset and only because
-			// we use PseudoArbArgsGenerator this corresponds to a regular offset in the sequence.
+			// we use PseudoArbArgsGenerator this corresponds to a regular offset in the Sequence.
 			a1s.zip(a2s)
 		),
 	)
@@ -60,7 +65,7 @@ class SemiOrderedZipArbTest : AbstractOrderedArgsGeneratorWithoutAnnotationsTest
 					.zip(randomGenerator) { pair, a3 ->
 						pair.mapSecond { it to a3 }
 					},
-				a1s.flatMap { a1 -> a2s.map { a2 -> a1 to (a2 to a2) } }
+				a1s.flatMap { a1 -> a2sZipped.map { a1 to it } }
 			),
 			Tuple(
 				"zip with 3 random",
@@ -68,7 +73,7 @@ class SemiOrderedZipArbTest : AbstractOrderedArgsGeneratorWithoutAnnotationsTest
 					.zip(randomGenerator) { (a1, a2, a3), a4 ->
 						a1 to Triple(a2, a3, a4)
 					},
-				a1s.flatMap { a1 -> a2s.map { a2 -> a1 to Triple(a2, a2, a2) } }
+				a1s.flatMap { a1 -> a2sZipped2.map { a1 to it } }
 			),
 			Tuple(
 				"zipDependent",

--- a/src/test/kotlin/com/tegonal/variist/providers/ArgsProviderTest.kt
+++ b/src/test/kotlin/com/tegonal/variist/providers/ArgsProviderTest.kt
@@ -50,7 +50,7 @@ class ArgsProviderTest {
 
 	@ParameterizedTest
 	@ArgsSource("rawArgs")
-	fun rawArgsIsSplit(index: Int, value: Long) {
+	fun rawArgs_isSplit(index: Int, value: Long) {
 		val (expectedIndex, expectValue) = rawArgs()[index].get()
 		expect(value).toEqual(expectValue as Long)
 		expect(index).toEqual(expectedIndex as Int)
@@ -58,7 +58,7 @@ class ArgsProviderTest {
 
 	@ParameterizedTest
 	@ArgsSource("orderedArgs")
-	fun orderedArgsIsSplit(index: Int, value: Long) {
+	fun orderedArgs_isSplit(index: Int, value: Long) {
 		val (expectedIndex, expectValue) = rawArgs()[index].get()
 		expect(value).toEqual(expectValue as Long)
 		expect(index).toEqual(expectedIndex as Int)
@@ -66,7 +66,7 @@ class ArgsProviderTest {
 
 	@ParameterizedTest
 	@ArgsSource("arbArgs")
-	fun arbArgsIsSplit(index: Int, value: Long) {
+	fun arbArgs_isSplit(index: Int, value: Long) {
 		val (expectedIndex, expectValue) = rawArgs()[index].get()
 		expect(value).toEqual(expectValue as Long)
 		expect(index).toEqual(expectedIndex as Int)
@@ -74,7 +74,7 @@ class ArgsProviderTest {
 
 	@ParameterizedTest
 	@ArgsSource("rawPairs")
-	fun rawPairIsSplit(index: Int, value: Long) {
+	fun rawPair_isSplit(index: Int, value: Long) {
 		val (expectedIndex, expectValue) = rawPairs()[index]
 		expect(value).toEqual(expectValue)
 		expect(index).toEqual(expectedIndex)
@@ -82,7 +82,7 @@ class ArgsProviderTest {
 
 	@ParameterizedTest
 	@ArgsSource("orderedPairs")
-	fun orderedPairIsSplit(index: Int, value: Long) {
+	fun orderedPair_isSplit(index: Int, value: Long) {
 		val (expectedIndex, expectValue) = rawPairs()[index]
 		expect(value).toEqual(expectValue)
 		expect(index).toEqual(expectedIndex)
@@ -90,7 +90,7 @@ class ArgsProviderTest {
 
 	@ParameterizedTest
 	@ArgsSource("arbPairs")
-	fun arbPairIsSplit(index: Int, value: Long) {
+	fun arbPair_isSplit(index: Int, value: Long) {
 		val (expectedIndex, expectValue) = rawPairs()[index]
 		expect(value).toEqual(expectValue)
 		expect(index).toEqual(expectedIndex)
@@ -98,7 +98,7 @@ class ArgsProviderTest {
 
 	@ParameterizedTest
 	@ArgsSource("rawPairsInList")
-	fun rawPairInListIsNotSplit(p: List<Pair<Int, Long>>) {
+	fun rawPairInList_isNotSplit(p: List<Pair<Int, Long>>) {
 		expect(p).toHaveSize(1)
 		val (index, value) = p.first()
 		val (expectedIndex, expectValue) = rawPairs()[index]
@@ -109,7 +109,7 @@ class ArgsProviderTest {
 
 	@ParameterizedTest
 	@ArgsSource("rawTupleLike")
-	fun rawTupleLikeIsNotSplit(tupleLike: Tuple4LikeStructure<Int, Long, Double, Float>) {
+	fun rawTupleLike_isNotSplit(tupleLike: Tuple4LikeStructure<Int, Long, Double, Float>) {
 		// TODO would be nicer if we take the index from ParameterizedTest, could be possible with junit 5.4/6
 		val expectedTupleLike = rawTupleLike()[tupleLike.a1]
 		expect(tupleLike).toEqual(expectedTupleLike)
@@ -117,7 +117,7 @@ class ArgsProviderTest {
 
 	@ParameterizedTest
 	@ArgsSource("orderedTupleLike")
-	fun orderedTupleLikeIsNotSplit(tupleLike: Tuple4LikeStructure<Int, Long, Double, Float>) {
+	fun orderedTupleLike_isNotSplit(tupleLike: Tuple4LikeStructure<Int, Long, Double, Float>) {
 		// TODO would be nicer if we take the index from ParameterizedTest, could be possible with junit 5.4/6
 		val expectedTupleLike = rawTupleLike()[tupleLike.a1]
 		expect(tupleLike).toEqual(expectedTupleLike)
@@ -125,7 +125,7 @@ class ArgsProviderTest {
 
 	@ParameterizedTest
 	@ArgsSource("arbTupleLike")
-	fun arbTupleLikeIsNotSplit(tupleLike: Tuple4LikeStructure<Int, Long, Double, Float>) {
+	fun arbTupleLike_isNotSplit(tupleLike: Tuple4LikeStructure<Int, Long, Double, Float>) {
 		// TODO would be nicer if we take the index from ParameterizedTest, could be possible with junit 5.4/6
 		val expectedTupleLike = rawTupleLike()[tupleLike.a1]
 		expect(tupleLike).toEqual(expectedTupleLike)
@@ -134,21 +134,65 @@ class ArgsProviderTest {
 
 	@ParameterizedTest
 	@ArgsSource("rawNestedTuples")
-	fun rawNestedTuplesAreFlattenedAndSplit(i: Int, l: Long, d: Double) {
+	fun rawNestedTuples_areFlattenedAndSplit(i: Int, l: Long, d: Double) {
 		expect(i.toDouble() + l.toDouble()).toEqual(d)
 	}
 
 	@ParameterizedTest
 	@ArgsSource("orderedNestedTuples")
-	fun orderedNestedTuplesAreFlattenedAndSplit(i: Int, l: Long, d: Double) {
+	fun orderedNestedTuples_areFlattenedAndSplit(i: Int, l: Long, d: Double) {
 		expect(i.toDouble() + l.toDouble()).toEqual(d)
 	}
 
 	@ParameterizedTest
 	@ArgsSource("arbNestedTuples")
-	fun arbNestedTuplesAreFlattenedAndSplit(i: Int, l: Long, d: Double) {
+	fun arbNestedTuples_areFlattenedAndSplit(i: Int, l: Long, d: Double) {
 		expect(i.toDouble() + l.toDouble()).toEqual(d)
 	}
+
+	@ParameterizedTest
+	@ArgsSource("tupleOfOrdered")
+	fun tupleOfOrdered_areSplit(i: Int, c: Char, l: Long) {
+		expect(i.toLong() + c.code).toEqual(l)
+	}
+
+	@ParameterizedTest
+	@ArgsSource("tupleOfArb")
+	fun tupleOfArb_areSplit(i: Int, c: Char, l: Long) {
+		expect(i.toLong() + c.code).toEqual(l)
+	}
+
+	@ParameterizedTest
+	@ArgsSource("tupleOfOrderedReturningTuples")
+	fun tupleOfOrderedReturningTuples_areFlattenedAndSplit(i1: Int, i2: Int, c1: Char, c2: Char, l: Long) {
+		expect(i1.toLong() + i2 + c1.code + c2.code).toEqual(l)
+	}
+
+	@ParameterizedTest
+	@ArgsSource("tupleOfArbReturningTuples")
+	fun tupleOfArbReturningTuples_areFlattenedAndSplit(i1: Int, i2: Int, c1: Char, c2: Char, l: Long) {
+		expect(i1.toLong() + i2 + c1.code + c2.code).toEqual(l)
+	}
+
+	@ParameterizedTest
+	@ArgsSource("tupleOfOrderedAndArbReturningTuples")
+	fun tupleOfOrderedAndArbReturningTuples_areFlattenedAndSplit(i1: Int, i2: Int, c1: Char, c2: Char, l: Long) {
+		expect(i1.toLong() + i2 + c1.code + c2.code).toEqual(l)
+	}
+
+	@ParameterizedTest
+	@ArgsSource("pairOfSemiOrdered")
+	fun pairOfSemiOrderedNotTheSameValues(a: String, b: String) {
+		expect(a).notToEqual(b)
+	}
+
+	@ParameterizedTest
+	@ArgsSource("tupleOfOrderedWithTwoArb")
+	@ArgsSourceOptions(minArgsOverridesSizeLimit = true, requestedMinArgs = 10)
+	fun tupleOfOrderedWithTwoArbNottheSamevalues(@Suppress("unused") i: Int, a: String, b: String) {
+		expect(a).notToEqual(b)
+	}
+
 
 	@ParameterizedTest
 	@ArgsSource("orderedWithSuffixArgsGenerator")
@@ -237,5 +281,35 @@ class ArgsProviderTest {
 					}
 				))
 		)
+
+		@JvmStatic
+		fun tupleOfOrdered() = Tuple(ordered.of(1), ordered.of('a'), ordered.of(1 + 'a'.code.toLong()))
+
+		@JvmStatic
+		fun tupleOfOrderedReturningTuples() =
+			Tuple(ordered.of(1 to 2), ordered.of('a' to 'b'), ordered.of(1 + 2 + 'a'.code.toLong() + 'b'.code))
+
+		@JvmStatic
+		fun tupleOfArbReturningTuples() =
+			Tuple(arb.of(1 to 2), arb.of('a' to 'b'), arb.of(1 + 2 + 'a'.code.toLong() + 'b'.code))
+
+		@JvmStatic
+		fun tupleOfOrderedAndArbReturningTuples() =
+			Tuple(ordered.of(1 to 2), arb.of('a' to 'b'), arb.of(1 + 2 + 'a'.code.toLong() + 'b'.code))
+
+		@JvmStatic
+		fun tupleOfArb() = Tuple(arb.of(1), arb.of('a'), arb.of(1 + 'a'.code.toLong()))
+
+		@JvmStatic
+		fun pairOfSemiOrdered() = run {
+			val g = ordered.intFromUntil(1, 10).zip(arb.string(minLength = 1, maxLength = 5)) { _, s -> s }
+			Tuple(g, g)
+		}
+
+		@JvmStatic
+		fun tupleOfOrderedWithTwoArb() = run {
+			val g = { arb.string(minLength = 10, maxLength = 20) }
+			Tuple(ordered.of(1, 2), g(), g())
+		}
 	}
 }


### PR DESCRIPTION
this is a breaking change for folks implementing own SemiOrderedArgsGenerator as they need to implement CoreSemiOrderedArgsGenerator now as well. We doubt consumers of this library are already that advanced and hence introduce the break.



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/variist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
