### PR TITLE
use golden ratio for seed offset instead of 1

### DIFF
--- a/misc/tools/readme-examples/src/test/kotlin/readme/examples/ArbExample.kt
+++ b/misc/tools/readme-examples/src/test/kotlin/readme/examples/ArbExample.kt
@@ -16,6 +16,7 @@ class ArbExample : ReadmeTest {
 		//snippet-arb-provider-insert
 	}
 
+	@Suppress("UNUSED_ANONYMOUS_PARAMETER")
 	@Test
 	fun `code-arb-1`() {
 		//snippet-ordered-1-insert

--- a/src/main/kotlin/com/tegonal/variist/generators/arbString.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/arbString.kt
@@ -2,6 +2,7 @@ package com.tegonal.variist.generators
 
 import com.tegonal.variist.config._components
 import com.tegonal.variist.config.createVariistRandom
+import com.tegonal.variist.generators.impl.SEED_OFFSET_STEP
 import com.tegonal.variist.generators.impl.mapIndexedInternal
 import com.tegonal.variist.utils.impl.failIfNegative
 import kotlin.random.Random
@@ -36,9 +37,9 @@ fun ArbExtensionPoint.string(
 
 	val componentFactoryContainer = _components
 	return intFromTo(minLength, maxLength).mapIndexedInternal { index, length, seedOffset ->
-		// +1 so we don't use the same seed as intFromTo otherwise for the first string it will always be:
+		// + SEED_OFFSET_STEP so we don't use the same seed as intFromTo otherwise for the first string it will always be:
 		// length of the resulting string = first code point
-		componentFactoryContainer.createVariistRandom(seedBaseOffset + seedOffset + index + 1).let { random ->
+		componentFactoryContainer.createVariistRandom(seedBaseOffset + seedOffset + index + SEED_OFFSET_STEP).let { random ->
 			val sb = StringBuilder(length)
 			var count = 0
 

--- a/src/main/kotlin/com/tegonal/variist/generators/arbZip.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/arbZip.kt
@@ -3,6 +3,8 @@
 
 package com.tegonal.variist.generators
 
+import com.tegonal.variist.generators.impl.SEED_OFFSET_STEP
+
 /**
  * Zips `this` [ArbArgsGenerator] with the given [other]&nbsp;[ArbArgsGenerator], [transform]ing
  * the pairwise generated values of type [A1] and [A2] to type [R].
@@ -23,7 +25,7 @@ fun <A1, A2, R> ArbArgsGenerator<A1>.zip(
 	other: ArbArgsGenerator<A2>,
 	transform: (A1, A2) -> R
 ): ArbArgsGenerator<R> {
-	val offset = this._core.seedBaseOffset + 1
+	val offset = _core.seedBaseOffset + SEED_OFFSET_STEP
 	return transform { seq, seedOffset ->
 		seq.zip(other.generate(offset + seedOffset), transform)
 	}

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/BaseSemiOrderedArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/BaseSemiOrderedArgsGenerator.kt
@@ -21,13 +21,15 @@ abstract class BaseSemiOrderedArgsGenerator<T>(
 
 	constructor(arbGenerator: CoreSemiOrderedArgsGenerator<*>, size: Int) : this(
 		arbGenerator.componentFactoryContainer,
-		arbGenerator.seedBaseOffset + 1,
+		// expected that this can overflow in the worst case
+		arbGenerator.seedBaseOffset + SEED_OFFSET_STEP,
 		size
 	)
 
 	constructor(arbGenerator: CoreSemiOrderedArgsGenerator<*>, size: Long) : this(
 		arbGenerator.componentFactoryContainer,
-		arbGenerator.seedBaseOffset + 1,
+		// expected that this can overflow in the worst case
+		arbGenerator.seedBaseOffset + SEED_OFFSET_STEP,
 		size
 	)
 

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/SemiOrderedFlatZipArbArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/SemiOrderedFlatZipArbArgsGenerator.kt
@@ -19,9 +19,9 @@ class SemiOrderedFlatZipArbArgsGenerator<A1, A2, R>(
 		val orderedOffset = offset / amount
 		val transformationOffset = offset % amount
 		val a1 = semiOrderedArgsGenerator.generateOne(orderedOffset)
-		// note, no need to do generate(offset + seedBaseOffset) here because _core.arb already passes the
-		// seedBaseOffset to the generated ArbArgsGenerator
-		val a2 = _core.arb.otherFactory(a1).generate(seedOffset = 0)
+		// Note, no need to do generate(offset + seedBaseOffset) here because _core.arb already passes the
+		// seedBaseOffset during the creation of ArbArgsGenerator
+		val a2 = _core.arb.otherFactory(a1).generate(seedOffset = offset)
 			.drop(transformationOffset).first()
 		return transform(a1, a2)
 	}
@@ -31,7 +31,7 @@ class SemiOrderedFlatZipArbArgsGenerator<A1, A2, R>(
 		val orderedOffset = offset / amount
 		val transformationOffset = offset % amount
 		return semiOrderedArgsGenerator.flatMapIndexedInternal { index, a1: A1 ->
-			_core.arb.otherFactory(a1).generate(seedOffset = index)
+			_core.arb.otherFactory(a1).generate(seedOffset = offset + index)
 				.take(amount).drop(transformationOffset).map { a2 ->
 					transform(a1, a2)
 				}

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/generatorExtensionPoints.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/generatorExtensionPoints.kt
@@ -20,19 +20,19 @@ abstract class BaseGeneratorExtensionPoint(
 		get() = DefaultArbExtensionPoint(
 			componentFactoryContainer,
 			// expected that this can overflow in the worst case
-			seedBaseOffset + 1
+			seedBaseOffset + SEED_OFFSET_STEP
 		)
 	override val ordered: OrderedExtensionPoint
 		get() = DefaultOrderedExtensionPoint(
 			componentFactoryContainer,
 			// expected that this can overflow in the worst case
-			seedBaseOffset + 1
+			seedBaseOffset + SEED_OFFSET_STEP
 		)
 	override val semiOrdered: SemiOrderedExtensionPoint
 		get() = DefaultSemiOrderedExtensionPoint(
 			componentFactoryContainer,
 			// expected that this can overflow in the worst case
-			seedBaseOffset + 1
+			seedBaseOffset + SEED_OFFSET_STEP
 		)
 }
 

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/utils.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/utils.kt
@@ -75,3 +75,14 @@ fun throwDontKnowHowToConvertToArgsGenerator(notAnArgsGenerator: Any?): Nothing 
 fun throwMaterialisingSemiOrderedArgsGeneratorNotSupported(): Nothing {
 	throw UnsupportedOperationException("Materialising SemiOrderedArgsGenerator is not supported out of the box to prevent bugs in the test setup")
 }
+
+/**
+ * golden ratio, used as a multiplier because we had clashes when using 1. For instance, when using
+ * seed=-434151884 two arb.string, produces the same sequence
+ *
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 2.3.0
+ */
+const val SEED_OFFSET_STEP = 0x9E3779B9.toInt()

--- a/src/test/kotlin/com/tegonal/variist/generators/ArbDateLikeTest.kt
+++ b/src/test/kotlin/com/tegonal/variist/generators/ArbDateLikeTest.kt
@@ -11,7 +11,7 @@ class ArbDateLikeTest : AbstractArbArgsGeneratorTest<Any>() {
 		ZonedDateTime.now().truncatedTo(ChronoUnit.HOURS).let { nowZonedDateTime ->
 			val nowLocalDateTime = nowZonedDateTime.toLocalDateTime()
 			val nowLocalTime = nowZonedDateTime.toLocalTime().let {
-				if (it.plusHours(2) > LocalTime.of(0, 0)) LocalTime.of(21, 0) else it
+				if (it.plusHours(2) >= LocalTime.of(0, 0)) LocalTime.of(21, 0) else it
 			}
 			val nowLocalDate = nowZonedDateTime.toLocalDate()
 			val nowOffsetDateTime = nowZonedDateTime.toOffsetDateTime()

--- a/src/test/kotlin/com/tegonal/variist/generators/ArbPseudoCombinatorTest.kt
+++ b/src/test/kotlin/com/tegonal/variist/generators/ArbPseudoCombinatorTest.kt
@@ -17,13 +17,14 @@ class ArbPseudoCombinatorTest {
 
 	val a1s = sequenceOf(1, 2, 3, 4)
 	val a2s = sequenceOf('a', 'b', 'c', 'd')
-	val a2sAfterCombine = a2s.drop(1) + sequenceOf('a')
+	// zip shifts by SEED_OFFSET_STEP which results in an offset of 3 in the end
+	val a2sAfterZip = sequenceOf('d', 'a', 'b', 'c')
 
 	@Test
 	fun zip() {
 		val a1generator = PseudoArbArgsGenerator(a1s)
 		val generator = a1generator.zip(PseudoArbArgsGenerator(a2s))
-		val expected = a1s.zip(a2sAfterCombine)
+		val expected = a1s.zip(a2sAfterZip)
 		val oneCombined = expected.take(1).toList()
 		val fourCombined = expected.take(4).toList()
 
@@ -42,7 +43,7 @@ class ArbPseudoCombinatorTest {
 		val f: (Int, Char) -> Tuple2<Int, Char> = { a1, a2 -> a1 to a2 }
 		val a1generator = PseudoArbArgsGenerator(a1s)
 		val generator = a1generator.zip(PseudoArbArgsGenerator(a2s), f)
-		val expected = a1s.zip(a2sAfterCombine, f)
+		val expected = a1s.zip(a2sAfterZip, f)
 		val oneCombined = expected.take(1).toList()
 		val fourCombined = expected.take(4).toList()
 
@@ -60,7 +61,7 @@ class ArbPseudoCombinatorTest {
 	fun combineAll() {
 		val a1generator = PseudoArbArgsGenerator(a1s)
 		val generator = Tuple(a1generator, PseudoArbArgsGenerator(a2s)).combineAll()
-		val expected = a1s.zip(a2sAfterCombine)
+		val expected = a1s.zip(a2sAfterZip)
 		val oneCombined = expected.take(1).toList()
 		val fourCombined = expected.take(4).toList()
 

--- a/src/test/kotlin/com/tegonal/variist/generators/ArbRangeTest.kt
+++ b/src/test/kotlin/com/tegonal/variist/generators/ArbRangeTest.kt
@@ -55,7 +55,7 @@ class ArbRangeTest : AbstractArbArgsGeneratorTest<Any>() {
 
 	@ParameterizedTest
 	@ArgsSource("validationErrors")
-	fun check_invariants(@Suppress("unused") what: String, errorMsg: String, factory: () -> ArbArgsGenerator<*>) {
+	fun check_invariants(@Suppress("unused", "UNUSED_PARAMETER") what: String, errorMsg: String, factory: () -> ArbArgsGenerator<*>) {
 		expect(factory).toThrow<IllegalStateException> {
 			messageToContain(errorMsg)
 		}

--- a/src/test/kotlin/com/tegonal/variist/generators/ArbSeedOffsetTest.kt
+++ b/src/test/kotlin/com/tegonal/variist/generators/ArbSeedOffsetTest.kt
@@ -5,6 +5,7 @@ import ch.tutteli.atrium.api.verbs.expect
 import ch.tutteli.kbox.Tuple
 import com.tegonal.variist.config._components
 import com.tegonal.variist.config.arb
+import com.tegonal.variist.generators.impl.SEED_OFFSET_STEP
 import com.tegonal.variist.testutils.orderedWithSeed0
 import com.tegonal.variist.testutils.withMockedRandom
 import org.junit.jupiter.api.Test
@@ -21,7 +22,9 @@ class ArbSeedOffsetTest {
 		val a1s = listOfPairs.map { it.first }
 		val a2s = listOfPairs.map { it.second }
 		expect(a1s).toEqual((0..9).toList())
-		expect(a2s).toEqual((10..19).toList())
+		@Suppress("INTEGER_OVERFLOW")
+		val offsetA2s = SEED_OFFSET_STEP * 10
+		expect(a2s).toEqual((offsetA2s..offsetA2s + 9).toList())
 	}
 
 	@Test
@@ -34,7 +37,9 @@ class ArbSeedOffsetTest {
 		val a1s = listOfPairs.map { it.first }
 		val a2s = listOfPairs.map { it.second }
 		expect(a1s).toEqual((20..29).toList())
-		expect(a2s).toEqual((30..39).toList())
+		@Suppress("INTEGER_OVERFLOW")
+		val offsetA2s = (SEED_OFFSET_STEP + 2) * 10
+		expect(a2s).toEqual((offsetA2s..offsetA2s + 9).toList())
 	}
 
 	@Test
@@ -47,7 +52,9 @@ class ArbSeedOffsetTest {
 		val a1s = listOfPairs.map { it.first }
 		val a2s = listOfPairs.map { it.second }
 		expect(a1s).toEqual((0..9).toList())
-		expect(a2s).toEqual((10..100 step 10).toList())
+		@Suppress("INTEGER_OVERFLOW")
+		val offsetA2s = SEED_OFFSET_STEP * 10
+		expect(a2s).toEqual((offsetA2s..offsetA2s + 90 step 10).toList())
 	}
 
 	@Test
@@ -60,7 +67,9 @@ class ArbSeedOffsetTest {
 		val a1s = listOfPairs.map { it.first }
 		val a2s = listOfPairs.map { it.second }
 		expect(a1s).toEqual((30..39).toList())
-		expect(a2s).toEqual((40..130 step 10).toList())
+		@Suppress("INTEGER_OVERFLOW")
+		val offsetA2s = (SEED_OFFSET_STEP + 3) * 10
+		expect(a2s).toEqual((offsetA2s..offsetA2s + 90 step 10).toList())
 	}
 
 	@Test
@@ -73,7 +82,9 @@ class ArbSeedOffsetTest {
 			val a1s = arb1.int().generateAndTake(10).toList()
 			val a2s = arb2.int().generateAndTake(10).toList()
 			expect(a1s).toEqual((0..9).toList())
-			expect(a2s).toEqual((10..19).toList())
+			@Suppress("INTEGER_OVERFLOW")
+			val offsetA2s = SEED_OFFSET_STEP * 10
+			expect(a2s).toEqual((offsetA2s..offsetA2s + 9).toList())
 		}
 	}
 }

--- a/src/test/kotlin/com/tegonal/variist/generators/SemiOrderedWithArbCombineAllTest.kt
+++ b/src/test/kotlin/com/tegonal/variist/generators/SemiOrderedWithArbCombineAllTest.kt
@@ -10,9 +10,11 @@ class SemiOrderedWithArbCombineAllTest : AbstractOrderedArgsGeneratorWithoutAnno
 	val a1s = listOf(1, 2)
 	val a2s = listOf('a', 'b', 'c')
 
-	// implementation detail, since we do seedBaseOffset+1 in BaseSemiOrderedArgsGenerator the a2s are shifted
-	val a2sZipped = listOf(Tuple('a', 'b'), Tuple('b', 'c'), Tuple('c', 'a'))
-	val a2sZipped2 = listOf(Tuple('a', 'b', 'c'), Tuple('b', 'c', 'a'), Tuple('c', 'a', 'b'))
+	// implementation detail, since we do seedBaseOffset + SEED_OFFSET_STEP in BaseSemiOrderedArgsGenerator
+	// the a2s are shifted by SEED_OFFSET_STEP
+	val a2sZipped1 = listOf('c','a','b')
+	val a2sZipped2 = listOf(Tuple('c', 'b'), Tuple('a', 'c'), Tuple('b', 'a'))
+	val a2sZipped3 = listOf(Tuple('c', 'b', 'a'), Tuple('a', 'c', 'b'), Tuple('b', 'a', 'c'))
 
 	val generator: SemiOrderedArgsGenerator<Int> = customComponentFactoryContainer.ordered.fromList(a1s)
 	val randomGenerator = PseudoArbArgsGenerator(a2s)
@@ -21,13 +23,13 @@ class SemiOrderedWithArbCombineAllTest : AbstractOrderedArgsGeneratorWithoutAnno
 		Tuple(
 			"combine with 1 random",
 			Tuple(generator, randomGenerator).combineAll(),
-			a1s.zip(a2s)
+			a1s.zip(a2sZipped1)
 		),
 		Tuple(
 			"combine with 2 random",
 			Tuple(generator, randomGenerator, randomGenerator).combineAll()
 				.map { (a1, a2, a3) -> a1 to (a2 to a3) },
-			a1s.zip(a2sZipped)
+			a1s.zip(a2sZipped2)
 		),
 		Tuple(
 			"combine with 3 random",
@@ -35,7 +37,7 @@ class SemiOrderedWithArbCombineAllTest : AbstractOrderedArgsGeneratorWithoutAnno
 				.map { (a1, a2, a3, a4) ->
 					a1 to Triple(a2, a3, a4)
 				},
-			a1s.zip(a2sZipped2)
+			a1s.zip(a2sZipped3)
 		)
 	)
 
@@ -50,7 +52,7 @@ class SemiOrderedWithArbCombineAllTest : AbstractOrderedArgsGeneratorWithoutAnno
 				"combine with 2 random",
 				Tuple(generator, randomGenerator, randomGenerator).combineAll()
 					.map { (a1, a2, a3) -> a1 to (a2 to a3) },
-				a1s.flatMap { a1 -> a2sZipped.map { a1 to it } }
+				a1s.flatMap { a1 -> a2sZipped2.map { a1 to it } }
 			),
 			Tuple(
 				"combine with 3 random",
@@ -58,7 +60,7 @@ class SemiOrderedWithArbCombineAllTest : AbstractOrderedArgsGeneratorWithoutAnno
 					.map { (a1, a2, a3, a4) ->
 						a1 to Triple(a2, a3, a4)
 					},
-				a1s.flatMap { a1 -> a2sZipped2.map { a1 to it } }
+				a1s.flatMap { a1 -> a2sZipped3.map { a1 to it } }
 			)
 		)
 

--- a/src/test/kotlin/com/tegonal/variist/generators/SemiOrderedZipArbTest.kt
+++ b/src/test/kotlin/com/tegonal/variist/generators/SemiOrderedZipArbTest.kt
@@ -10,9 +10,11 @@ class SemiOrderedZipArbTest : AbstractOrderedArgsGeneratorWithoutAnnotationsTest
 	val a1s = listOf(1, 2)
 	val a2s = listOf('a', 'b', 'c')
 
-	// implementation detail, since we do seedBaseOffset+1 in BaseSemiOrderedArgsGenerator the a2s are shifted
-	val a2sZipped = listOf(Tuple('a', 'b'), Tuple('b', 'c'), Tuple('c', 'a'))
-	val a2sZipped2 = listOf(Tuple('a', 'b', 'c'), Tuple('b', 'c', 'a'), Tuple('c', 'a', 'b'))
+	// implementation detail, since we do seedBaseOffset + SEED_OFFSET_STEP in BaseSemiOrderedArgsGenerator
+	// the a2s are shifted by SEED_OFFSET_STEP
+	val a2sZipped1 = listOf('c','a','b')
+	val a2sZipped2 = listOf(Tuple('c', 'b'), Tuple('a', 'c'), Tuple('b', 'a'))
+	val a2sZipped3 = listOf(Tuple('c', 'b', 'a'), Tuple('a', 'c', 'b'), Tuple('b', 'a', 'c'))
 
 	val generator = customComponentFactoryContainer.ordered.fromList(a1s)
 	val randomGenerator = PseudoArbArgsGenerator(a2s)
@@ -23,7 +25,7 @@ class SemiOrderedZipArbTest : AbstractOrderedArgsGeneratorWithoutAnnotationsTest
 			generator.zip(randomGenerator),
 			// zip is only correct because for most tests we don't take more than generator.size
 			// see createGeneratorsAllPossibleCombinations where we need to use flatMap
-			a1s.zip(a2s)
+			a1s.zip(a2sZipped1)
 		),
 		Tuple(
 			"zip with 2 random",
@@ -31,7 +33,7 @@ class SemiOrderedZipArbTest : AbstractOrderedArgsGeneratorWithoutAnnotationsTest
 				.zip(randomGenerator) { pair, a3 ->
 					pair.mapSecond { it to a3 }
 				},
-			a1s.zip(a2sZipped)
+			a1s.zip(a2sZipped2)
 		),
 		Tuple(
 			"zip with 3 random",
@@ -39,7 +41,7 @@ class SemiOrderedZipArbTest : AbstractOrderedArgsGeneratorWithoutAnnotationsTest
 				.zip(randomGenerator) { (a1, a2, a3), a4 ->
 					a1 to Triple(a2, a3, a4)
 				},
-			a1s.zip(a2sZipped2)
+			a1s.zip(a2sZipped3)
 		),
 		Tuple(
 			"zipDependent",
@@ -65,7 +67,7 @@ class SemiOrderedZipArbTest : AbstractOrderedArgsGeneratorWithoutAnnotationsTest
 					.zip(randomGenerator) { pair, a3 ->
 						pair.mapSecond { it to a3 }
 					},
-				a1s.flatMap { a1 -> a2sZipped.map { a1 to it } }
+				a1s.flatMap { a1 -> a2sZipped2.map { a1 to it } }
 			),
 			Tuple(
 				"zip with 3 random",
@@ -73,7 +75,7 @@ class SemiOrderedZipArbTest : AbstractOrderedArgsGeneratorWithoutAnnotationsTest
 					.zip(randomGenerator) { (a1, a2, a3), a4 ->
 						a1 to Triple(a2, a3, a4)
 					},
-				a1s.flatMap { a1 -> a2sZipped2.map { a1 to it } }
+				a1s.flatMap { a1 -> a2sZipped3.map { a1 to it } }
 			),
 			Tuple(
 				"zipDependent",

--- a/src/test/kotlin/com/tegonal/variist/generators/UnicodeRangeTest.kt
+++ b/src/test/kotlin/com/tegonal/variist/generators/UnicodeRangeTest.kt
@@ -61,7 +61,7 @@ class UnicodeRangeTest {
 
 
 //	@Test
-	@Suppress("KotlinUnreachableCode")
+	@Suppress("UNREACHABLE_CODE")
 	fun charsCorrectlyAssigned() {
 		// deactivated as the unicode-list is rather static and this test takes about 20s, activate if you change something
 		return

--- a/src/test/kotlin/com/tegonal/variist/providers/ArgsProviderTest.kt
+++ b/src/test/kotlin/com/tegonal/variist/providers/ArgsProviderTest.kt
@@ -189,7 +189,7 @@ class ArgsProviderTest {
 	@ParameterizedTest
 	@ArgsSource("tupleOfOrderedWithTwoArb")
 	@ArgsSourceOptions(minArgsOverridesSizeLimit = true, requestedMinArgs = 10)
-	fun tupleOfOrderedWithTwoArbNottheSamevalues(@Suppress("unused") i: Int, a: String, b: String) {
+	fun tupleOfOrderedWithTwoArbNotTheSameValues(@Suppress("unused", "UNUSED_PARAMETER") i: Int, a: String, b: String) {
 		expect(a).notToEqual(b)
 	}
 
@@ -302,7 +302,7 @@ class ArgsProviderTest {
 
 		@JvmStatic
 		fun pairOfSemiOrdered() = run {
-			val g = ordered.intFromUntil(1, 10).zip(arb.string(minLength = 1, maxLength = 5)) { _, s -> s }
+			val g = ordered.intFromUntil(1, 11).zip(arb.string(minLength = 10, maxLength = 20)) { _, s -> s }
 			Tuple(g, g)
 		}
 

--- a/src/test/kotlin/com/tegonal/variist/testutils/PseudoArbArgsGenerator.kt
+++ b/src/test/kotlin/com/tegonal/variist/testutils/PseudoArbArgsGenerator.kt
@@ -5,6 +5,7 @@ import com.tegonal.variist.config._components
 import com.tegonal.variist.generators.arb
 import com.tegonal.variist.generators.impl.BaseArbArgsGenerator
 import com.tegonal.variist.utils.repeatForever
+import kotlin.math.absoluteValue
 
 class PseudoArbArgsGenerator<T>(
 	private val list: List<T>,
@@ -19,5 +20,5 @@ class PseudoArbArgsGenerator<T>(
 	) : this(finiteSequence.toList(), seedBaseOffset, componentFactoryContainer)
 
 	override fun generate(seedOffset: Int): Sequence<T> =
-		repeatForever().flatMap { list }.drop((seedBaseOffset + seedOffset) % list.size)
+		repeatForever().flatMap { list }.drop((seedBaseOffset + seedOffset).absoluteValue % list.size)
 }


### PR DESCRIPTION
In order that the different arb are less likely to correlate.

moreover:
- pass the offset to ArbArgsGenerator created in SemiOrderedFlatZipArbArgsGenerator
- adjust suppression so that we no longer see warnings during `build`



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/variist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
