### PR TITLE
add arbZoneId/Offset and add them to arb.zoned/OffsetDateTime

### DIFF
--- a/src/main/kotlin/com/tegonal/variist/generators/arbDateLike.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/arbDateLike.kt
@@ -5,6 +5,7 @@ import com.tegonal.variist.generators.impl.*
 import java.time.*
 import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalUnit
+import kotlin.math.sign
 
 /**
  * Returns an [ArbArgsGenerator] which generates [LocalTime]s ranging from [LocalTime.MIN] to inclusive [LocalTime.MAX]
@@ -67,13 +68,14 @@ fun ArbExtensionPoint.localDateTimeFromUntil(
  *
  * @since 2.0.0
  */
-//TODO 3.0.0 also define a parameter to steer timezone
 fun ArbExtensionPoint.zonedDateTimeFromUntil(
 	from: ZonedDateTime,
 	toExclusive: ZonedDateTime,
 	temporalUnit: TemporalUnit,
+	arbZoneId: ArbArgsGenerator<ZoneId> = zoneId(),
 ): ArbArgsGenerator<ZonedDateTime> =
 	ZonedDateTimeFromUntilArbArgsGenerator(_components, from, toExclusive, temporalUnit)
+		.withZoneSameInstant(arbZoneId)
 
 /**
  * Returns an [ArbArgsGenerator] which generates [OffsetDateTime]s ranging [from] (inclusive) to [toExclusive]
@@ -83,13 +85,14 @@ fun ArbExtensionPoint.zonedDateTimeFromUntil(
  *
  * @since 2.0.0
  */
-//TODO 3.0.0 also define a parameter to steer the offset
 fun ArbExtensionPoint.offsetDateTimeFromUntil(
 	from: OffsetDateTime,
 	toExclusive: OffsetDateTime,
 	temporalUnit: TemporalUnit,
+	arbZoneOffset: ArbArgsGenerator<ZoneOffset> = zoneOffset()
 ): ArbArgsGenerator<OffsetDateTime> =
 	OffsetDateTimeFromUntilArbArgsGenerator(_components, from, toExclusive, temporalUnit)
+		.withOffsetSameInstant(arbZoneOffset)
 
 /**
  * Returns an [ArbArgsGenerator] which generates [LocalTime]s ranging [from] (inclusive) to [toInclusive]
@@ -143,13 +146,14 @@ fun ArbExtensionPoint.localDateTimeFromTo(
  *
  * @since 2.0.0
  */
-//TODO 3.0.0 also define a parameter to steer timezone
 fun ArbExtensionPoint.zonedDateTimeFromTo(
 	from: ZonedDateTime,
 	toInclusive: ZonedDateTime,
-	temporalUnit: TemporalUnit
+	temporalUnit: TemporalUnit,
+	arbZoneId: ArbArgsGenerator<ZoneId> = zoneId()
 ): ArbArgsGenerator<ZonedDateTime> =
 	ZonedDateTimeFromToArbArgsGenerator(_components, from, toInclusive, temporalUnit)
+		.withZoneSameInstant(arbZoneId)
 
 /**
  * Returns an [ArbArgsGenerator] which generates [OffsetDateTime]s ranging [from] (inclusive) to [toInclusive]
@@ -159,13 +163,34 @@ fun ArbExtensionPoint.zonedDateTimeFromTo(
  *
  * @since 2.0.0
  */
-//TODO 3.0.0 also define a parameter to steer the offset
 fun ArbExtensionPoint.offsetDateTimeFromTo(
 	from: OffsetDateTime,
 	toInclusive: OffsetDateTime,
-	temporalUnit: TemporalUnit
+	temporalUnit: TemporalUnit,
+	arbZoneOffset: ArbArgsGenerator<ZoneOffset> = zoneOffset()
 ): ArbArgsGenerator<OffsetDateTime> =
 	OffsetDateTimeFromToArbArgsGenerator(_components, from, toInclusive, temporalUnit)
+		.withOffsetSameInstant(arbZoneOffset)
+
+/**
+ * Returns an [ArbArgsGenerator] which generates [ZoneId]s.
+ *
+ * @since 2.3.0
+ */
+fun ArbExtensionPoint.zoneId(): ArbArgsGenerator<ZoneId> = arb.fromList(zoneIds)
+
+private val zoneIds by lazy { ZoneId.getAvailableZoneIds().map { ZoneId.of(it) } }
+
+/**
+ * Returns an [ArbArgsGenerator] which generates [ZoneId]s.
+ *
+ * @since 2.3.0
+ */
+fun ArbExtensionPoint.zoneOffset(): ArbArgsGenerator<ZoneOffset> =
+	arb.intFromTo(-18, 18).zip(arb.intFromTo(0, 59)).zip(arb.intFromTo(0, 59)) { (h, m), s ->
+		if (h == 18 || h == -18) ZoneOffset.ofHours(h)
+		else ZoneOffset.ofHoursMinutesSeconds(h, m * h.sign, s * h.sign)
+	}
 
 /**
  * Adjust the [ZoneId] of the generated [ZonedDateTime] based on the given [ArbArgsGenerator].

--- a/src/main/kotlin/com/tegonal/variist/providers/PredefinedArgsProviders.kt
+++ b/src/main/kotlin/com/tegonal/variist/providers/PredefinedArgsProviders.kt
@@ -12,4 +12,5 @@ interface PredefinedArgsProviders :
 	PredefinedBooleanProviders,
 	PredefinedBoundProviders,
 	PredefinedCharProviders,
-	PredefinedNumberProviders
+	PredefinedNumberProviders,
+	PredefinedDateRelatedProviders

--- a/src/main/kotlin/com/tegonal/variist/providers/PredefinedDateRelatedProviders.kt
+++ b/src/main/kotlin/com/tegonal/variist/providers/PredefinedDateRelatedProviders.kt
@@ -1,0 +1,30 @@
+package com.tegonal.variist.providers
+
+import com.tegonal.variist.generators.*
+
+/**
+ * Provides predefined providers around [Int], [Long] and other [Number] based on the default [arb] and [ordered].
+ *
+ * @since 2.3.0
+ */
+interface PredefinedDateRelatedProviders {
+	companion object {
+		/**
+		 * See [arb.localTime()][ArbExtensionPoint.localTime]
+		 */
+		@JvmStatic
+		fun arbLocalTime() = arb.localTime()
+
+		/**
+		 * See [arb.zoneId()][ArbExtensionPoint.zoneId]
+		 */
+		@JvmStatic
+		fun arbZoneId() = arb.zoneId()
+
+		/**
+		 * See [arb.zoneOffset()][ArbExtensionPoint.zoneOffset]
+		 */
+		@JvmStatic
+		fun arbZoneOffset() = arb.zoneOffset()
+	}
+}

--- a/src/test/kotlin/com/tegonal/variist/generators/ArbDateLikeTest.kt
+++ b/src/test/kotlin/com/tegonal/variist/generators/ArbDateLikeTest.kt
@@ -9,116 +9,124 @@ import java.time.temporal.ChronoUnit
 
 class ArbDateLikeTest : AbstractArbArgsGeneratorTest<Any>() {
 
-	override fun createGenerators(modifiedArb: ArbExtensionPoint) =
-		ZonedDateTime.now().truncatedTo(ChronoUnit.HOURS).let { nowZonedDateTime ->
-			val nowLocalDateTime = nowZonedDateTime.toLocalDateTime()
-			val nowLocalTime = nowZonedDateTime.toLocalTime().let {
-				if (it.plusHours(2) >= LocalTime.of(0, 0)) LocalTime.of(21, 0) else it
-			}
-			val nowLocalDate = nowZonedDateTime.toLocalDate()
-			val nowOffsetDateTime = nowZonedDateTime.toOffsetDateTime()
-			sequenceOf(
-				Tuple(
-					"localTime",
-					modifiedArb.localTime(ChronoUnit.HOURS),
-					(0..23).map { LocalTime.of(it, 0, 0) }
+	override fun createGenerators(modifiedArb: ArbExtensionPoint) = run {
+		val zoneId = ZoneId.systemDefault()
+		val zoneOffset = ZoneOffset.ofHours(1)
+		val tokyo = ZoneId.of("Asia/Tokyo")
+		val nowZonedDateTime = ZonedDateTime.now().truncatedTo(ChronoUnit.HOURS)
+		val nowLocalDateTime = nowZonedDateTime.toLocalDateTime()
+		val nowLocalTime = nowZonedDateTime.toLocalTime().let {
+			if (it.plusHours(2) >= LocalTime.of(0, 0)) LocalTime.of(21, 0) else it
+		}
+		val nowLocalDate = nowZonedDateTime.toLocalDate()
+		val nowOffsetDateTime = nowZonedDateTime.toOffsetDateTime().withOffsetSameInstant(zoneOffset)
+		sequenceOf(
+			Tuple(
+				"localTime",
+				modifiedArb.localTime(ChronoUnit.HOURS),
+				(0..23).map { LocalTime.of(it, 0, 0) }
+			),
+			Tuple(
+				"localTimeFromUntil",
+				modifiedArb.localTimeFromUntil(nowLocalTime, nowLocalTime.plusHours(2), ChronoUnit.HOURS),
+				listOf(nowLocalTime, nowLocalTime.plusHours(1))
+			),
+			Tuple(
+				"localDateFromUntil",
+				modifiedArb.localDateFromUntil(nowLocalDate, nowLocalDate.plusDays(2), ChronoUnit.DAYS),
+				listOf(nowLocalDate, nowLocalDate.plusDays(1))
+			),
+			Tuple(
+				"localDateTimeFromUntil",
+				modifiedArb.localDateTimeFromUntil(
+					nowLocalDateTime,
+					nowLocalDateTime.plusDays(1),
+					ChronoUnit.HOURS
 				),
-				Tuple(
-					"localTimeFromUntil",
-					modifiedArb.localTimeFromUntil(nowLocalTime, nowLocalTime.plusHours(2), ChronoUnit.HOURS),
-					listOf(nowLocalTime, nowLocalTime.plusHours(1))
+				(0L..23).map { nowLocalDateTime.plusHours(it) }
+			),
+			Tuple(
+				"zonedDateTimeFromUntil",
+				modifiedArb.zonedDateTimeFromUntil(
+					nowZonedDateTime,
+					nowZonedDateTime.plusHours(3),
+					ChronoUnit.MINUTES,
+					// need to fix it as the test uses equals
+					arbZoneId = arb.of(zoneId)
 				),
-				Tuple(
-					"localDateFromUntil",
-					modifiedArb.localDateFromUntil(nowLocalDate, nowLocalDate.plusDays(2), ChronoUnit.DAYS),
-					listOf(nowLocalDate, nowLocalDate.plusDays(1))
+				(0L until 3 * 60).map { nowZonedDateTime.plusMinutes(it) }
+			),
+			Tuple(
+				"zonedDateTimeFromUntil.withZoneSameInstant",
+				modifiedArb.zonedDateTimeFromUntil(
+					nowZonedDateTime,
+					nowZonedDateTime.plusHours(3),
+					ChronoUnit.MINUTES
+				).withZoneSameInstant(arb.of(tokyo)),
+				(0L until 3 * 60).map { nowZonedDateTime.withZoneSameInstant(tokyo).plusMinutes(it) }
+			),
+			Tuple(
+				"offsetDateTimeFromUntil",
+				modifiedArb.offsetDateTimeFromUntil(
+					nowOffsetDateTime,
+					nowOffsetDateTime.plusMinutes(2),
+					ChronoUnit.SECONDS,
+					// need to fix it as the test uses equals
+					arbZoneOffset = arb.of(zoneOffset)
 				),
+				(0L until 2 * 60).map { nowOffsetDateTime.plusSeconds(it) }
+			),
+			ZoneOffset.ofHoursMinutes(3, 14).let { offset ->
 				Tuple(
-					"localDateTimeFromUntil",
-					modifiedArb.localDateTimeFromUntil(
-						nowLocalDateTime,
-						nowLocalDateTime.plusDays(1),
-						ChronoUnit.HOURS
-					),
-					(0L..23).map { nowLocalDateTime.plusHours(it) }
-				),
-				Tuple(
-					"zonedDateTimeFromUntil",
-					modifiedArb.zonedDateTimeFromUntil(
-						nowZonedDateTime,
-						nowZonedDateTime.plusHours(3),
-						ChronoUnit.MINUTES
-					),
-					(0L until 3 * 60).map { nowZonedDateTime.plusMinutes(it) }
-				),
-				ZoneId.of("Asia/Tokyo").let { tokyo ->
-					Tuple(
-						"zonedDateTimeFromUntil.withZoneSameInstant",
-						modifiedArb.zonedDateTimeFromUntil(
-							nowZonedDateTime,
-							nowZonedDateTime.plusHours(3),
-							ChronoUnit.MINUTES
-						).withZoneSameInstant(arb.of(tokyo)),
-						(0L until 3 * 60).map { nowZonedDateTime.withZoneSameInstant(tokyo).plusMinutes(it) }
-					)
-				},
-				Tuple(
-					"offsetDateTimeFromUntil",
+					"offsetDateTimeFromUntil.withOffsetSameInstant",
 					modifiedArb.offsetDateTimeFromUntil(
 						nowOffsetDateTime,
 						nowOffsetDateTime.plusMinutes(2),
 						ChronoUnit.SECONDS
-					),
-					(0L until 2 * 60).map { nowOffsetDateTime.plusSeconds(it) }
+					).withOffsetSameInstant(arb.of(offset)),
+					(0L until 2 * 60).map { nowOffsetDateTime.withOffsetSameInstant(offset).plusSeconds(it) }
+				)
+			},
+			Tuple(
+				"localTimeFromTo",
+				modifiedArb.localTimeFromTo(nowLocalTime, nowLocalTime.plusMinutes(2), ChronoUnit.MINUTES),
+				listOf(nowLocalTime, nowLocalTime.plusMinutes(1), nowLocalTime.plusMinutes(2))
+			),
+			Tuple(
+				"localDateFromTo",
+				modifiedArb.localDateFromTo(nowLocalDate, nowLocalDate.plusDays(2), ChronoUnit.DAYS),
+				listOf(nowLocalDate, nowLocalDate.plusDays(1), nowLocalDate.plusDays(2))
+			),
+			Tuple(
+				"localDateTimeFromTo",
+				modifiedArb.localDateTimeFromTo(
+					nowLocalDateTime,
+					nowLocalDateTime.plus(13, ChronoUnit.MILLIS),
+					ChronoUnit.MILLIS
 				),
-				ZoneOffset.ofHoursMinutes(3, 14).let { offset ->
-					Tuple(
-						"offsetDateTimeFromUntil.withOffsetSameInstant",
-						modifiedArb.offsetDateTimeFromUntil(
-							nowOffsetDateTime,
-							nowOffsetDateTime.plusMinutes(2),
-							ChronoUnit.SECONDS
-						).withOffsetSameInstant(arb.of(offset)),
-						(0L until 2 * 60).map { nowOffsetDateTime.withOffsetSameInstant(offset).plusSeconds(it) }
-					)
-				},
-				Tuple(
-					"localTimeFromTo",
-					modifiedArb.localTimeFromTo(nowLocalTime, nowLocalTime.plusMinutes(2), ChronoUnit.MINUTES),
-					listOf(nowLocalTime, nowLocalTime.plusMinutes(1), nowLocalTime.plusMinutes(2))
+				(0L..13).map { nowLocalDateTime.plus(it, ChronoUnit.MILLIS) }
+			),
+			Tuple(
+				"zonedDateTimeFromTo",
+				modifiedArb.zonedDateTimeFromTo(
+					nowZonedDateTime,
+					nowZonedDateTime.plus(11, ChronoUnit.MICROS),
+					ChronoUnit.MICROS,
+					// need to fix it as the test uses equals
+					arbZoneId = arb.of(zoneId)
 				),
-				Tuple(
-					"localDateFromTo",
-					modifiedArb.localDateFromTo(nowLocalDate, nowLocalDate.plusDays(2), ChronoUnit.DAYS),
-					listOf(nowLocalDate, nowLocalDate.plusDays(1), nowLocalDate.plusDays(2))
+				(0L..11).map { nowZonedDateTime.plus(it, ChronoUnit.MICROS) }
+			),
+			Tuple(
+				"offsetDateTimeFromTo",
+				modifiedArb.offsetDateTimeFromTo(
+					nowOffsetDateTime,
+					nowOffsetDateTime.plusMinutes(1),
+					ChronoUnit.SECONDS,
+					arbZoneOffset = arb.of(zoneOffset)
 				),
-				Tuple(
-					"localDateTimeFromTo",
-					modifiedArb.localDateTimeFromTo(
-						nowLocalDateTime,
-						nowLocalDateTime.plus(13, ChronoUnit.MILLIS),
-						ChronoUnit.MILLIS
-					),
-					(0L..13).map { nowLocalDateTime.plus(it, ChronoUnit.MILLIS) }
-				),
-				Tuple(
-					"zonedDateTimeFromTo",
-					modifiedArb.zonedDateTimeFromTo(
-						nowZonedDateTime,
-						nowZonedDateTime.plus(11, ChronoUnit.MICROS),
-						ChronoUnit.MICROS
-					),
-					(0L..11).map { nowZonedDateTime.plus(it, ChronoUnit.MICROS) }
-				),
-				Tuple(
-					"offsetDateTimeFromTo",
-					modifiedArb.offsetDateTimeFromTo(
-						nowOffsetDateTime,
-						nowOffsetDateTime.plusMinutes(1),
-						ChronoUnit.SECONDS
-					),
-					(0L..1 * 60).map { nowOffsetDateTime.plusSeconds(it) }
-				),
-			)
-		}
+				(0L..1 * 60).map { nowOffsetDateTime.plusSeconds(it) }
+			),
+		)
+	}
 }


### PR DESCRIPTION
this way we create samples in the requested range but with maybe unexpected zone ids and offsets. I.e. we more likely catch bugs which expect always a predefined zoneId/Offset



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/variist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
