### PR TITLE
drop support for jdk11, update to gradle 9 and build against jdk 25

### DIFF
--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -13,9 +13,8 @@ const {MatrixBuilder} = require('./matrix_builder');
 const {configureKotlinDefaults, javaDistributionAxis, javaVersionAxis, setMatrix} = require('./matrix_commons');
 
 const matrix = new MatrixBuilder();
-// we are not ready yet for jdk25 as it requires gradle 9.x which no longer supports jdk11 but we still want
-// to support jdk11 for now
-const withoutJdk25 = {...javaVersionAxis, values: javaVersionAxis.values.filter(x => x != '25') };
+// we no longer support jdk 11
+const withoutJdk25 = {...javaVersionAxis, values: javaVersionAxis.values.filter(x => x !== '11') };
 configureKotlinDefaults(matrix, javaDistributionAxis, withoutJdk25);
 
 setMatrix(matrix, 4);

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ dependencies {
 Minimum requirements:
 
 - Kotlin: 1.9
-- JDK: 11
+- JDK: 17
 - JUnit: 5.13.0
 
 # Examples

--- a/gradle/build-logic/build-parameters/build.gradle.kts
+++ b/gradle/build-logic/build-parameters/build.gradle.kts
@@ -11,7 +11,7 @@ buildParameters {
 	// Other plugins can contribute parameters, so below list is not exhaustive, hence we disable the validation
 	enableValidation.set(false)
 
-	val defaultJdkVersion = 11
+	val defaultJdkVersion = 17
 	integer("defaultJdkVersion") {
 		defaultValue.set(defaultJdkVersion)
 		mandatory.set(true)

--- a/gradle/build-logic/dev/src/main/kotlin/build-logic.kotlin-conventions.gradle.kts
+++ b/gradle/build-logic/dev/src/main/kotlin/build-logic.kotlin-conventions.gradle.kts
@@ -10,6 +10,10 @@ plugins {
 	id("ch.tutteli.gradle.plugins.junitjacoco")
 }
 
+junitjacoco {
+	jacoco.toolVersion = "0.8.15"
+}
+
 tasks.configureEach<KotlinCompile> {
 	compilerOptions {
 		jvmTarget.set(JvmTarget.fromTarget(buildParameters.defaultJdkVersion.toString()))

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/scripts/cleanup-on-push-to-main.sh
+++ b/scripts/cleanup-on-push-to-main.sh
@@ -21,9 +21,9 @@ sourceOnce "$scriptsDir/run-shfmt.sh"
 
 function cleanupOnPushToMain() {
 	customRunShfmt || die "was not able to format"
-	"$projectDir/gradlew" generateAll
-	"$projectDir/gradlew" :readme-examples:build
-	logSuccess "code generated"
+	"$projectDir/gradlew" generateAll || die "was not able to generateAll"
+	"$projectDir/gradlew" :readme-examples:build || die "was not able to build the readme examples"
+	logSuccess "formatted shell scripts and generated code"
 }
 
 ${__SOURCED__:+return}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,12 +17,12 @@ dependencyResolutionManagement {
 
 rootProject.name = "variist"
 
-include("misc/tools", "readme-examples")
+includeProject("misc/tools", "readme-examples")
 
-fun Settings_gradle.include(subPath: String, projectName: String) {
-	val dir = file("${rootProject.projectDir}/$subPath/$projectName")
-	if (!dir.exists()) {
-		throw GradleException("cannot include project $projectName as its projectDir $dir does not exist")
+fun Settings.includeProject(subPath: String, projectName: String) {
+	val dir = file("$rootDir/$subPath/$projectName")
+	require(dir.isDirectory) {
+		"Cannot include project `$projectName` because its projectDir file://$dir does not exist."
 	}
 	include(projectName)
 	project(":$projectName").projectDir = dir


### PR DESCRIPTION
moreover:
- update jacoco tool version
- rename Settings.include extension method as there is now an include which takes multiple project paths



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/variist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
