### PR TITLE
ConstantOrderedArgsGenerator and helpers to reduce code duplication

### DIFF
--- a/src/main/kotlin/com/tegonal/variist/generators/arbFromArray.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/arbFromArray.kt
@@ -1,8 +1,6 @@
 package com.tegonal.variist.generators
 
-import com.tegonal.variist.config._components
-import com.tegonal.variist.generators.impl.ConstantArbArgsGenerator
-import com.tegonal.variist.generators.impl.checkNotEmptyReturnNullIfOneElementAndOtherwiseIntFromUntilSize
+import com.tegonal.variist.generators.impl.checkNotEmptyCreateIndexBasedGenerator
 
 /**
  * Returns an [ArbArgsGenerator] based on the given [args].
@@ -10,8 +8,7 @@ import com.tegonal.variist.generators.impl.checkNotEmptyReturnNullIfOneElementAn
  * @since 2.0.0
  */
 fun ArbExtensionPoint.fromArray(args: ByteArray): ArbArgsGenerator<Byte> =
-	checkNotEmptyReturnNullIfOneElementAndOtherwiseIntFromUntilSize(args.size)?.map(args::get)
-		?: ConstantArbArgsGenerator(_components, args.first())
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 /**
  * Returns an [ArbArgsGenerator] based on the given [args].
@@ -19,8 +16,7 @@ fun ArbExtensionPoint.fromArray(args: ByteArray): ArbArgsGenerator<Byte> =
  * @since 2.0.0
  */
 fun ArbExtensionPoint.fromArray(args: CharArray): ArbArgsGenerator<Char> =
-	checkNotEmptyReturnNullIfOneElementAndOtherwiseIntFromUntilSize(args.size)?.map(args::get)
-		?: ConstantArbArgsGenerator(_components, args.first())
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 
 /**
@@ -29,8 +25,7 @@ fun ArbExtensionPoint.fromArray(args: CharArray): ArbArgsGenerator<Char> =
  * @since 2.0.0
  */
 fun ArbExtensionPoint.fromArray(args: ShortArray): ArbArgsGenerator<Short> =
-	checkNotEmptyReturnNullIfOneElementAndOtherwiseIntFromUntilSize(args.size)?.map(args::get)
-		?: ConstantArbArgsGenerator(_components, args.first())
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 /**
  * Returns an [ArbArgsGenerator] based on the given [args].
@@ -38,8 +33,7 @@ fun ArbExtensionPoint.fromArray(args: ShortArray): ArbArgsGenerator<Short> =
  * @since 2.0.0
  */
 fun ArbExtensionPoint.fromArray(args: IntArray): ArbArgsGenerator<Int> =
-	checkNotEmptyReturnNullIfOneElementAndOtherwiseIntFromUntilSize(args.size)?.map(args::get)
-		?: ConstantArbArgsGenerator(_components, args.first())
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 /**
  * Returns an [ArbArgsGenerator] based on the given [args].
@@ -47,8 +41,7 @@ fun ArbExtensionPoint.fromArray(args: IntArray): ArbArgsGenerator<Int> =
  * @since 2.0.0
  */
 fun ArbExtensionPoint.fromArray(args: LongArray): ArbArgsGenerator<Long> =
-	checkNotEmptyReturnNullIfOneElementAndOtherwiseIntFromUntilSize(args.size)?.map(args::get)
-		?: ConstantArbArgsGenerator(_components, args.first())
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 /**
  * Returns an [ArbArgsGenerator] based on the given [args].
@@ -56,8 +49,7 @@ fun ArbExtensionPoint.fromArray(args: LongArray): ArbArgsGenerator<Long> =
  * @since 2.0.0
  */
 fun ArbExtensionPoint.fromArray(args: FloatArray): ArbArgsGenerator<Float> =
-	checkNotEmptyReturnNullIfOneElementAndOtherwiseIntFromUntilSize(args.size)?.map(args::get)
-		?: ConstantArbArgsGenerator(_components, args.first())
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 /**
  * Returns an [ArbArgsGenerator] based on the given [args].
@@ -65,8 +57,7 @@ fun ArbExtensionPoint.fromArray(args: FloatArray): ArbArgsGenerator<Float> =
  * @since 2.0.0
  */
 fun ArbExtensionPoint.fromArray(args: DoubleArray): ArbArgsGenerator<Double> =
-	checkNotEmptyReturnNullIfOneElementAndOtherwiseIntFromUntilSize(args.size)?.map(args::get)
-		?: ConstantArbArgsGenerator(_components, args.first())
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 /**
  * Returns an [ArbArgsGenerator] based on the given [args].
@@ -74,8 +65,7 @@ fun ArbExtensionPoint.fromArray(args: DoubleArray): ArbArgsGenerator<Double> =
  * @since 2.0.0
  */
 fun ArbExtensionPoint.fromArray(args: BooleanArray): ArbArgsGenerator<Boolean> =
-	checkNotEmptyReturnNullIfOneElementAndOtherwiseIntFromUntilSize(args.size)?.map(args::get)
-		?: ConstantArbArgsGenerator(_components, args.first())
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 /**
  * Returns an [ArbArgsGenerator] based on the given [args].
@@ -83,5 +73,4 @@ fun ArbExtensionPoint.fromArray(args: BooleanArray): ArbArgsGenerator<Boolean> =
  * @since 2.0.0
  */
 fun <T> ArbExtensionPoint.fromArray(args: Array<out T>): ArbArgsGenerator<T> =
-	checkNotEmptyReturnNullIfOneElementAndOtherwiseIntFromUntilSize(args.size)?.map(args::get)
-		?: ConstantArbArgsGenerator(_components, args.first())
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)

--- a/src/main/kotlin/com/tegonal/variist/generators/arbFromList.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/arbFromList.kt
@@ -1,8 +1,6 @@
 package com.tegonal.variist.generators
 
-import com.tegonal.variist.config._components
-import com.tegonal.variist.generators.impl.ConstantArbArgsGenerator
-import com.tegonal.variist.generators.impl.checkNotEmptyReturnNullIfOneElementAndOtherwiseIntFromUntilSize
+import com.tegonal.variist.generators.impl.checkNotEmptyCreateIndexBasedGenerator
 
 /**
  * Returns an [ArbArgsGenerator] based on the given [args].
@@ -11,8 +9,7 @@ import com.tegonal.variist.generators.impl.checkNotEmptyReturnNullIfOneElementAn
  */
 @JvmName("fromValueList")
 fun <T> ArbExtensionPoint.fromList(args: List<T>): ArbArgsGenerator<T> =
-	checkNotEmptyReturnNullIfOneElementAndOtherwiseIntFromUntilSize(args.size)?.map(args::get)
-		?: ConstantArbArgsGenerator(_components, args.first())
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 /**
  * Returns an [ArbArgsGenerator] based on the given [weightWithValueList] which picks the next value

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/ConstantArbArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/ConstantArbArgsGenerator.kt
@@ -13,7 +13,7 @@ class ConstantArbArgsGenerator<T>(
 	componentFactoryContainer: ComponentFactoryContainer,
 	private val constant: T,
 ) : BaseArbArgsGenerator<T>(componentFactoryContainer) {
-	val sequence = repeatForever(constant)
+	private val sequence = repeatForever(constant)
 
 	override fun generateOne(seedOffset: Int): T = constant
 	override fun generate(seedOffset: Int): Sequence<T> = sequence

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/ConstantOrderedArgsGenerator.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/ConstantOrderedArgsGenerator.kt
@@ -1,0 +1,27 @@
+package com.tegonal.variist.generators.impl
+
+import com.tegonal.variist.config.ComponentFactoryContainer
+import com.tegonal.variist.config.ComponentFactoryContainerProvider
+import com.tegonal.variist.generators.OrderedArgsGenerator
+import com.tegonal.variist.utils.repeatForever
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+class ConstantOrderedArgsGenerator<T>(
+	override val componentFactoryContainer: ComponentFactoryContainer,
+	private val constant: T,
+) : OrderedArgsGenerator<T>, ComponentFactoryContainerProvider {
+	private val sequence = repeatForever(constant)
+
+	override val size: Int = 1
+
+	@Deprecated("Use generateOne without seedOffset because seedOffset is ignored. This method mainly exists so that you can abstract over SemiOrderedLikeArgsGenerator")
+	override fun generateOne(offset: Int, seedOffset: Int): T = constant
+
+	@Deprecated("Use generate without seedOffset because seedOffset is ignored. This method mainly exists so that you can abstract over SemiOrderedLikeArgsGenerator")
+	override fun generate(offset: Int, seedOffset: Int): Sequence<T> = sequence
+}

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/arbDateLikeGenerators.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/arbDateLikeGenerators.kt
@@ -1,13 +1,8 @@
 package com.tegonal.variist.generators.impl
 
 import com.tegonal.variist.config.ComponentFactoryContainer
-import java.time.Duration
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.OffsetDateTime
-import java.time.ZonedDateTime
-import java.time.temporal.ChronoUnit
+import com.tegonal.variist.generators.ArbArgsGenerator
+import java.time.*
 import java.time.temporal.Temporal
 import java.time.temporal.TemporalUnit
 import kotlin.random.Random
@@ -52,7 +47,7 @@ class LocalDateTimeFromUntilArbArgsGenerator(
 	componentFactoryContainer: ComponentFactoryContainer,
 	from: LocalDateTime,
 	toExclusive: LocalDateTime,
-	temporalUnit: TemporalUnit = ChronoUnit.DAYS,
+	temporalUnit: TemporalUnit,
 ) : TemporalFromUntilArbArgsGenerator<LocalDateTime>(
 	componentFactoryContainer, from, toExclusive, temporalUnit, LocalDateTime::plus
 )
@@ -67,7 +62,7 @@ class ZonedDateTimeFromUntilArbArgsGenerator(
 	componentFactoryContainer: ComponentFactoryContainer,
 	from: ZonedDateTime,
 	toExclusive: ZonedDateTime,
-	temporalUnit: TemporalUnit = ChronoUnit.DAYS,
+	temporalUnit: TemporalUnit,
 ) : TemporalFromUntilArbArgsGenerator<ZonedDateTime>(
 	componentFactoryContainer, from, toExclusive, temporalUnit, ZonedDateTime::plus
 )
@@ -82,7 +77,7 @@ class OffsetDateTimeFromUntilArbArgsGenerator(
 	componentFactoryContainer: ComponentFactoryContainer,
 	from: OffsetDateTime,
 	toExclusive: OffsetDateTime,
-	temporalUnit: TemporalUnit = ChronoUnit.DAYS,
+	temporalUnit: TemporalUnit,
 ) : TemporalFromUntilArbArgsGenerator<OffsetDateTime>(
 	componentFactoryContainer, from, toExclusive, temporalUnit, OffsetDateTime::plus
 )
@@ -99,11 +94,10 @@ fun LocalTimeFromToArbArgsGenerator(
 	from: LocalTime,
 	toInclusive: LocalTime,
 	temporalUnit: TemporalUnit
-) = if (from == toInclusive) {
-	ConstantArbArgsGenerator(componentFactoryContainer, from)
-} else {
-	InternalLocalTimeFromToArbArgsGenerator(componentFactoryContainer, from, toInclusive, temporalUnit)
-}
+) = constantIfFromIsToInclusiveOtherwise(
+	componentFactoryContainer, from, toInclusive, temporalUnit,
+	::InternalLocalTimeFromToArbArgsGenerator
+)
 
 /**
  * !! No backward compatibility guarantees !!
@@ -131,12 +125,11 @@ fun LocalDateFromToArbArgsGenerator(
 	componentFactoryContainer: ComponentFactoryContainer,
 	from: LocalDate,
 	toInclusive: LocalDate,
-	temporalUnit: TemporalUnit = ChronoUnit.DAYS
-) = if (from == toInclusive) {
-	ConstantArbArgsGenerator(componentFactoryContainer, from)
-} else {
-	InternalLocalDateFromToArbArgsGenerator(componentFactoryContainer, from, toInclusive, temporalUnit)
-}
+	temporalUnit: TemporalUnit
+) = constantIfFromIsToInclusiveOtherwise(
+	componentFactoryContainer, from, toInclusive, temporalUnit,
+	::InternalLocalDateFromToArbArgsGenerator
+)
 
 /**
  * !! No backward compatibility guarantees !!
@@ -164,12 +157,11 @@ fun LocalDateTimeFromToArbArgsGenerator(
 	componentFactoryContainer: ComponentFactoryContainer,
 	from: LocalDateTime,
 	toInclusive: LocalDateTime,
-	temporalUnit: TemporalUnit = ChronoUnit.DAYS
-) = if (from == toInclusive) {
-	ConstantArbArgsGenerator(componentFactoryContainer, from)
-} else {
-	InternalLocalDateTimeFromToArbArgsGenerator(componentFactoryContainer, from, toInclusive, temporalUnit)
-}
+	temporalUnit: TemporalUnit
+) = constantIfFromIsToInclusiveOtherwise(
+	componentFactoryContainer, from, toInclusive, temporalUnit,
+	::InternalLocalDateTimeFromToArbArgsGenerator
+)
 
 /**
  * !! No backward compatibility guarantees !!
@@ -197,12 +189,11 @@ fun ZonedDateTimeFromToArbArgsGenerator(
 	componentFactoryContainer: ComponentFactoryContainer,
 	from: ZonedDateTime,
 	toInclusive: ZonedDateTime,
-	temporalUnit: TemporalUnit = ChronoUnit.DAYS
-) = if (from == toInclusive) {
-	ConstantArbArgsGenerator(componentFactoryContainer, from)
-} else {
-	InternalZonedDateTimeFromToArbArgsGenerator(componentFactoryContainer, from, toInclusive, temporalUnit)
-}
+	temporalUnit: TemporalUnit
+) = constantIfPredicateHoldsOtherwiseFactory(
+	componentFactoryContainer, from, toInclusive, temporalUnit,
+	::InternalZonedDateTimeFromToArbArgsGenerator
+) { from.isEqual(toInclusive) }
 
 /**
  * !! No backward compatibility guarantees !!
@@ -230,12 +221,11 @@ fun OffsetDateTimeFromToArbArgsGenerator(
 	componentFactoryContainer: ComponentFactoryContainer,
 	from: OffsetDateTime,
 	toInclusive: OffsetDateTime,
-	temporalUnit: TemporalUnit = ChronoUnit.DAYS
-) = if (from == toInclusive) {
-	ConstantArbArgsGenerator(componentFactoryContainer, from)
-} else {
-	InternalOffsetDateTimeFromToArbArgsGenerator(componentFactoryContainer, from, toInclusive, temporalUnit)
-}
+	temporalUnit: TemporalUnit
+) = constantIfPredicateHoldsOtherwiseFactory(
+	componentFactoryContainer, from, toInclusive, temporalUnit,
+	::InternalOffsetDateTimeFromToArbArgsGenerator
+) { from.isEqual(toInclusive) }
 
 /**
  * !! No backward compatibility guarantees !!
@@ -263,7 +253,7 @@ abstract class TemporalFromUntilArbArgsGenerator<T>(
 	componentFactoryContainer: ComponentFactoryContainer,
 	from: T,
 	toExclusive: T,
-	private val temporalUnit: TemporalUnit = ChronoUnit.DAYS,
+	private val temporalUnit: TemporalUnit,
 	private val plusTyped: T.(Long, TemporalUnit) -> T,
 ) : OpenEndRangeBasedArbArgsGenerator<T>(
 	componentFactoryContainer,
@@ -285,7 +275,7 @@ abstract class TemporalFromToArbArgsGenerator<T>(
 	componentFactoryContainer: ComponentFactoryContainer,
 	from: T,
 	toInclusive: T,
-	private val temporalUnit: TemporalUnit = ChronoUnit.DAYS,
+	private val temporalUnit: TemporalUnit,
 	private val plusTyped: T.(Long, TemporalUnit) -> T,
 ) : ClosedRangeBasedArbArgsGenerator<T>(
 	componentFactoryContainer,
@@ -296,3 +286,28 @@ abstract class TemporalFromToArbArgsGenerator<T>(
 	final override fun nextElementInRange(random: Random): T =
 		from.plusTyped(random.nextLong(0, diffPlusOneInLong), temporalUnit)
 }
+
+private inline fun <T> constantIfFromIsToInclusiveOtherwise(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: T,
+	toInclusive: T,
+	temporalUnit: TemporalUnit,
+	factory: (ComponentFactoryContainer, from: T, toInclusive: T, TemporalUnit) -> ArbArgsGenerator<T>
+): ArbArgsGenerator<T> =
+	constantIfPredicateHoldsOtherwiseFactory(
+		componentFactoryContainer, from, toInclusive, temporalUnit, factory
+	) { from == toInclusive }
+
+private inline fun <T> constantIfPredicateHoldsOtherwiseFactory(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: T,
+	toInclusive: T,
+	temporalUnit: TemporalUnit,
+	factory: (ComponentFactoryContainer, from: T, toInclusive: T, TemporalUnit) -> ArbArgsGenerator<T>,
+	predicate: () -> Boolean
+): ArbArgsGenerator<T> =
+	if (predicate()) {
+		ConstantArbArgsGenerator(componentFactoryContainer, from)
+	} else {
+		factory(componentFactoryContainer, from, toInclusive, temporalUnit)
+	}

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/utils.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/utils.kt
@@ -1,9 +1,7 @@
 package com.tegonal.variist.generators.impl
 
-import com.tegonal.variist.generators.ArbArgsGenerator
-import com.tegonal.variist.generators.ArbExtensionPoint
-import com.tegonal.variist.generators.ArgsGenerator
-import com.tegonal.variist.generators.intFromUntil
+import com.tegonal.variist.config._components
+import com.tegonal.variist.generators.*
 import com.tegonal.variist.utils.impl.FEATURE_REQUEST_URL
 import com.tegonal.variist.utils.repeatForever
 
@@ -31,19 +29,39 @@ inline fun <A, B, R> zipForever(
  * !! No backward compatibility guarantees !!
  * Reuse at your own risk
  *
- * Checks that the given [size] is not 0, returns `null` if [size] is 1 and otherwise
- * [arb.intFromUntil][ArbExtensionPoint.intFromUntil] with from = 0 and until = [size].
+ * Checks that the given [size] is not 0
  *
  * @param size represents the number of elements passed to an [ArbArgsGenerator] factory.
  *
- * @since 2.0.0
+ * @since 3.0.0
  */
-fun ArbExtensionPoint.checkNotEmptyReturnNullIfOneElementAndOtherwiseIntFromUntilSize(size: Int) =
-	when (size) {
-		0 -> error("You must define at least one element, 0 given, cannot create an ArbArgsGenerator")
-		1 -> null
-		else -> intFromUntil(0, size)
-	}
+fun <T> ArbExtensionPoint.checkNotEmptyCreateIndexBasedGenerator(
+	size: Int,
+	elementAt: (index: Int) -> T
+): ArbArgsGenerator<T> = when (size) {
+	0 -> error("You must define at least one element, 0 given, cannot create an ArbArgsGenerator")
+	1 -> ConstantArbArgsGenerator(_components, elementAt(0))
+	else -> intFromUntil(0, size).map(elementAt)
+}
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * Checks that the given [size] is not 0
+ *
+ * @param size represents the number of elements passed to an [OrderedArgsGenerator] factory.
+ *
+ * @since 3.0.0
+ */
+fun <T> OrderedExtensionPoint.checkNotEmptyCreateIndexBasedGenerator(
+	size: Int,
+	elementAt: (index: Int) -> T
+): OrderedArgsGenerator<T> = when (size) {
+	0 -> error("You must define at least one element, 0 given, cannot create an OrderedArgsGenerator")
+	1 -> ConstantOrderedArgsGenerator(_components, elementAt(0))
+	else -> RandomAccessOrderedArgsGenerator(_components, size, elementAt)
+}
 
 /**
  * !! No backward compatibility guarantees !!

--- a/src/main/kotlin/com/tegonal/variist/generators/orderedFromArray.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/orderedFromArray.kt
@@ -2,7 +2,8 @@ package com.tegonal.variist.generators
 
 import com.tegonal.variist.config._components
 import com.tegonal.variist.generators.impl.ArrayOrderedArgsGenerator
-import com.tegonal.variist.generators.impl.RandomAccessOrderedArgsGenerator
+import com.tegonal.variist.generators.impl.ConstantOrderedArgsGenerator
+import com.tegonal.variist.generators.impl.checkNotEmptyCreateIndexBasedGenerator
 
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
@@ -10,7 +11,7 @@ import com.tegonal.variist.generators.impl.RandomAccessOrderedArgsGenerator
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromArray(args: ByteArray): OrderedArgsGenerator<Byte> =
-	RandomAccessOrderedArgsGenerator(_components, args.size) { args[it] }
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
@@ -18,8 +19,7 @@ fun OrderedExtensionPoint.fromArray(args: ByteArray): OrderedArgsGenerator<Byte>
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromArray(args: CharArray): OrderedArgsGenerator<Char> =
-	RandomAccessOrderedArgsGenerator(_components, args.size) { args[it] }
-
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
@@ -27,7 +27,7 @@ fun OrderedExtensionPoint.fromArray(args: CharArray): OrderedArgsGenerator<Char>
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromArray(args: ShortArray): OrderedArgsGenerator<Short> =
-	RandomAccessOrderedArgsGenerator(_components, args.size) { args[it] }
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
@@ -35,7 +35,7 @@ fun OrderedExtensionPoint.fromArray(args: ShortArray): OrderedArgsGenerator<Shor
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromArray(args: IntArray): OrderedArgsGenerator<Int> =
-	RandomAccessOrderedArgsGenerator(_components, args.size) { args[it] }
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
@@ -43,7 +43,7 @@ fun OrderedExtensionPoint.fromArray(args: IntArray): OrderedArgsGenerator<Int> =
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromArray(args: LongArray): OrderedArgsGenerator<Long> =
-	RandomAccessOrderedArgsGenerator(_components, args.size) { args[it] }
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
@@ -51,7 +51,7 @@ fun OrderedExtensionPoint.fromArray(args: LongArray): OrderedArgsGenerator<Long>
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromArray(args: FloatArray): OrderedArgsGenerator<Float> =
-	RandomAccessOrderedArgsGenerator(_components, args.size) { args[it] }
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
@@ -59,7 +59,7 @@ fun OrderedExtensionPoint.fromArray(args: FloatArray): OrderedArgsGenerator<Floa
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromArray(args: DoubleArray): OrderedArgsGenerator<Double> =
-	RandomAccessOrderedArgsGenerator(_components, args.size) { args[it] }
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
@@ -67,7 +67,7 @@ fun OrderedExtensionPoint.fromArray(args: DoubleArray): OrderedArgsGenerator<Dou
  * @since 2.0.0
  */
 fun OrderedExtensionPoint.fromArray(args: BooleanArray): OrderedArgsGenerator<Boolean> =
-	RandomAccessOrderedArgsGenerator(_components, args.size) { args[it] }
+	checkNotEmptyCreateIndexBasedGenerator(args.size, args::get)
 
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
@@ -75,4 +75,5 @@ fun OrderedExtensionPoint.fromArray(args: BooleanArray): OrderedArgsGenerator<Bo
  * @since 2.0.0
  */
 fun <T> OrderedExtensionPoint.fromArray(args: Array<out T>): OrderedArgsGenerator<T> =
-	ArrayOrderedArgsGenerator(_components, args)
+	if (args.size == 1) ConstantOrderedArgsGenerator(_components, args.first())
+	else ArrayOrderedArgsGenerator(_components, args)

--- a/src/main/kotlin/com/tegonal/variist/generators/orderedOf.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/orderedOf.kt
@@ -1,8 +1,5 @@
 package com.tegonal.variist.generators
 
-import com.tegonal.variist.config._components
-import com.tegonal.variist.generators.impl.ArrayOrderedArgsGenerator
-
 /**
  * Returns an [OrderedArgsGenerator] based on the given [args].
  *
@@ -10,4 +7,4 @@ import com.tegonal.variist.generators.impl.ArrayOrderedArgsGenerator
  */
 // note: not `arg: T, vararg args: T` on purpose for performance reasons, we have a check on size
 fun <T> OrderedExtensionPoint.of(vararg args: T): OrderedArgsGenerator<T> =
-	ArrayOrderedArgsGenerator(_components, args)
+	fromArray(args)


### PR DESCRIPTION
moreover:
- same helpers also for Arb
- add constant check to ordered.fromArray
- delegate to fromArray from ordered.of
- fix arbDateLike, use isEqual for Zoned/OffsetDateTime and not equals to determine if from and toIncluse are the same point in time



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/variist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
