### PR TITLE
ordered.dateLike

### DIFF
--- a/src/jmh/kotlin/com/tegonal/variist/Cartesian3Bench.kt
+++ b/src/jmh/kotlin/com/tegonal/variist/Cartesian3Bench.kt
@@ -5,7 +5,6 @@ package com.tegonal.variist
 import ch.tutteli.kbox.Tuple3
 import com.tegonal.variist.config._components
 import com.tegonal.variist.generators.*
-import com.tegonal.variist.generators.impl.BaseSemiOrderedArgsGenerator
 import com.tegonal.variist.generators.impl.BaseSemiOrderedLikeArgsGenerator
 import com.tegonal.variist.utils.deriveChildSeedOffset
 import org.openjdk.jmh.annotations.*

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/OrderedArgsGeneratorMapper.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/OrderedArgsGeneratorMapper.kt
@@ -11,7 +11,7 @@ import com.tegonal.variist.generators.OrderedArgsGenerator
  *
  * @since 3.0.0
  */
-class OrderedArgsGeneratorMapper<T, R>(
+open class OrderedArgsGeneratorMapper<T, R>(
 	private val baseGenerator: OrderedArgsGenerator<T>,
 	private val transform: (T) -> R
 ) : OrderedArgsGenerator<R>, ComponentFactoryContainerProvider {

--- a/src/main/kotlin/com/tegonal/variist/generators/impl/orderedDateLikeGenerators.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/impl/orderedDateLikeGenerators.kt
@@ -1,0 +1,321 @@
+package com.tegonal.variist.generators.impl
+
+import com.tegonal.variist.config.ComponentFactoryContainer
+import com.tegonal.variist.config.ordered
+import com.tegonal.variist.generators.OrderedArgsGenerator
+import com.tegonal.variist.generators.impl.BaseSemiOrderedLikeArgsGenerator.Companion.sizeLongToInt
+import com.tegonal.variist.generators.intFromUntil
+import com.tegonal.variist.utils.impl.requireFromLessThanOrEqualToExclusive
+import com.tegonal.variist.utils.impl.requireFromLessThanToExclusive
+import java.time.*
+import java.time.temporal.ChronoUnit
+import java.time.temporal.Temporal
+import java.time.temporal.TemporalUnit
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+class LocalTimeFromUntilOrderedArgsGenerator(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: LocalTime,
+	toExclusive: LocalTime,
+	temporalUnit: TemporalUnit,
+) : TemporalFromUntilOrderedArgsGenerator<LocalTime>(
+	componentFactoryContainer, from, toExclusive, temporalUnit, LocalTime::plus
+)
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+class LocalDateFromUntilOrderedArgsGenerator(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: LocalDate,
+	toExclusive: LocalDate,
+	temporalUnit: TemporalUnit,
+) : TemporalFromUntilOrderedArgsGenerator<LocalDate>(
+	componentFactoryContainer, from, toExclusive, temporalUnit, LocalDate::plus
+)
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+class LocalDateTimeFromUntilOrderedArgsGenerator(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: LocalDateTime,
+	toExclusive: LocalDateTime,
+	temporalUnit: TemporalUnit,
+) : TemporalFromUntilOrderedArgsGenerator<LocalDateTime>(
+	componentFactoryContainer, from, toExclusive, temporalUnit, LocalDateTime::plus
+)
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+class ZonedDateTimeFromUntilOrderedArgsGenerator(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: ZonedDateTime,
+	toExclusive: ZonedDateTime,
+	temporalUnit: TemporalUnit,
+) : TemporalFromUntilOrderedArgsGenerator<ZonedDateTime>(
+	componentFactoryContainer, from, toExclusive, temporalUnit, ZonedDateTime::plus
+)
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+class OffsetDateTimeFromUntilOrderedArgsGenerator(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: OffsetDateTime,
+	toExclusive: OffsetDateTime,
+	temporalUnit: TemporalUnit,
+) : TemporalFromUntilOrderedArgsGenerator<OffsetDateTime>(
+	componentFactoryContainer, from, toExclusive, temporalUnit, OffsetDateTime::plus
+)
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+@Suppress("FunctionName")
+fun LocalTimeFromToOrderedArgsGenerator(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: LocalTime,
+	toInclusive: LocalTime,
+	temporalUnit: TemporalUnit
+) = constantIfFromIsToInclusiveOtherwise(
+	componentFactoryContainer, from, toInclusive, temporalUnit,
+	::InternalLocalTimeFromToOrderedArgsGenerator
+)
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+private class InternalLocalTimeFromToOrderedArgsGenerator(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: LocalTime,
+	toInclusive: LocalTime,
+	temporalUnit: TemporalUnit
+) : TemporalFromToOrderedArgsGenerator<LocalTime>(
+	componentFactoryContainer, from, toInclusive, temporalUnit, LocalTime::plus
+)
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+@Suppress("FunctionName")
+fun LocalDateFromToOrderedArgsGenerator(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: LocalDate,
+	toInclusive: LocalDate,
+	temporalUnit: TemporalUnit = ChronoUnit.DAYS
+) = constantIfFromIsToInclusiveOtherwise(
+	componentFactoryContainer, from, toInclusive, temporalUnit,
+	::InternalLocalDateFromToOrderedArgsGenerator
+)
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+private class InternalLocalDateFromToOrderedArgsGenerator(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: LocalDate,
+	toInclusive: LocalDate,
+	temporalUnit: TemporalUnit
+) : TemporalFromToOrderedArgsGenerator<LocalDate>(
+	componentFactoryContainer, from, toInclusive, temporalUnit, LocalDate::plus
+)
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+@Suppress("FunctionName")
+fun LocalDateTimeFromToOrderedArgsGenerator(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: LocalDateTime,
+	toInclusive: LocalDateTime,
+	temporalUnit: TemporalUnit = ChronoUnit.DAYS
+) = constantIfFromIsToInclusiveOtherwise(
+	componentFactoryContainer, from, toInclusive, temporalUnit,
+	::InternalLocalDateTimeFromToOrderedArgsGenerator
+)
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+private class InternalLocalDateTimeFromToOrderedArgsGenerator(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: LocalDateTime,
+	toInclusive: LocalDateTime,
+	temporalUnit: TemporalUnit
+) : TemporalFromToOrderedArgsGenerator<LocalDateTime>(
+	componentFactoryContainer, from, toInclusive, temporalUnit, LocalDateTime::plus
+)
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+@Suppress("FunctionName")
+fun ZonedDateTimeFromToOrderedArgsGenerator(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: ZonedDateTime,
+	toInclusive: ZonedDateTime,
+	temporalUnit: TemporalUnit = ChronoUnit.DAYS
+) = constantIfPredicateHoldsOtherwiseFactory(
+	componentFactoryContainer, from, toInclusive, temporalUnit,
+	::InternalZonedDateTimeFromToOrderedArgsGenerator
+) { from.isEqual(toInclusive) }
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+private class InternalZonedDateTimeFromToOrderedArgsGenerator(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: ZonedDateTime,
+	toInclusive: ZonedDateTime,
+	temporalUnit: TemporalUnit
+) : TemporalFromToOrderedArgsGenerator<ZonedDateTime>(
+	componentFactoryContainer, from, toInclusive, temporalUnit, ZonedDateTime::plus
+)
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+@Suppress("FunctionName")
+fun OffsetDateTimeFromToOrderedArgsGenerator(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: OffsetDateTime,
+	toInclusive: OffsetDateTime,
+	temporalUnit: TemporalUnit = ChronoUnit.DAYS
+) = constantIfPredicateHoldsOtherwiseFactory(
+	componentFactoryContainer, from, toInclusive, temporalUnit,
+	::InternalOffsetDateTimeFromToOrderedArgsGenerator
+) { from.isEqual(toInclusive) }
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+private class InternalOffsetDateTimeFromToOrderedArgsGenerator(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: OffsetDateTime,
+	toInclusive: OffsetDateTime,
+	temporalUnit: TemporalUnit
+) : TemporalFromToOrderedArgsGenerator<OffsetDateTime>(
+	componentFactoryContainer, from, toInclusive, temporalUnit, OffsetDateTime::plus
+)
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+abstract class TemporalFromUntilOrderedArgsGenerator<T>(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: T,
+	toExclusive: T,
+	protected val temporalUnit: TemporalUnit = ChronoUnit.DAYS,
+	private val plusTyped: T.(Long, TemporalUnit) -> T,
+) : OrderedArgsGeneratorMapper<Int, T>(
+	run {
+		val size = temporalUnit.between(from, toExclusive)
+		componentFactoryContainer.ordered.intFromUntil(0, sizeLongToInt(size))
+	},
+	{ step -> from.plusTyped(step.toLong(), temporalUnit) }
+) where T : Temporal, T : Comparable<T> {
+	init {
+		requireFromLessThanToExclusive(from, toExclusive)
+	}
+}
+
+/**
+ * !! No backward compatibility guarantees !!
+ * Reuse at your own risk
+ *
+ * @since 3.0.0
+ */
+abstract class TemporalFromToOrderedArgsGenerator<T>(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: T,
+	toInclusive: T,
+	protected val temporalUnit: TemporalUnit = ChronoUnit.DAYS,
+	private val plusTyped: T.(Long, TemporalUnit) -> T,
+) : OrderedArgsGeneratorMapper<Int, T>(
+	run {
+		val size = Math.addExact(temporalUnit.between(from, toInclusive), 1)
+		componentFactoryContainer.ordered.intFromUntil(0, sizeLongToInt(size))
+	},
+	{ step -> from.plusTyped(step.toLong(), temporalUnit) }
+) where T : Temporal, T : Comparable<T> {
+	init {
+		requireFromLessThanOrEqualToExclusive(from, toInclusive)
+	}
+}
+
+private inline fun <T> constantIfFromIsToInclusiveOtherwise(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: T,
+	toInclusive: T,
+	temporalUnit: TemporalUnit,
+	factory: (ComponentFactoryContainer, from: T, toInclusive: T, TemporalUnit) -> OrderedArgsGenerator<T>
+): OrderedArgsGenerator<T> =
+	constantIfPredicateHoldsOtherwiseFactory(componentFactoryContainer, from, toInclusive, temporalUnit, factory) {
+		from == toInclusive
+	}
+
+private inline fun <T> constantIfPredicateHoldsOtherwiseFactory(
+	componentFactoryContainer: ComponentFactoryContainer,
+	from: T,
+	toInclusive: T,
+	temporalUnit: TemporalUnit,
+	factory: (ComponentFactoryContainer, from: T, toInclusive: T, TemporalUnit) -> OrderedArgsGenerator<T>,
+	predicate: () -> Boolean
+): OrderedArgsGenerator<T> =
+	if (predicate()) {
+		ConstantOrderedArgsGenerator(componentFactoryContainer, from)
+	} else {
+		factory(componentFactoryContainer, from, toInclusive, temporalUnit)
+	}

--- a/src/main/kotlin/com/tegonal/variist/generators/orderedDateLike.kt
+++ b/src/main/kotlin/com/tegonal/variist/generators/orderedDateLike.kt
@@ -1,0 +1,155 @@
+package com.tegonal.variist.generators
+
+import com.tegonal.variist.config._components
+import com.tegonal.variist.generators.impl.*
+import java.time.*
+import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalUnit
+
+/**
+ * Returns an [OrderedArgsGenerator] which generates [LocalTime]s ranging [from] (inclusive) to [toExclusive]
+ * where [temporalUnit] defines the steps.
+ *
+ * @since 3.0.0
+ */
+fun OrderedExtensionPoint.localTimeFromUntil(
+	from: LocalTime,
+	toExclusive: LocalTime,
+	temporalUnit: TemporalUnit,
+): OrderedArgsGenerator<LocalTime> =
+	LocalTimeFromUntilOrderedArgsGenerator(_components, from, toExclusive, temporalUnit)
+
+/**
+ * Returns an [OrderedArgsGenerator] which generates [LocalDate]s ranging [from] (inclusive) to [toExclusive]
+ * where [temporalUnit] defines the steps which defaults to [ChronoUnit.DAYS].
+ *
+ * @throws java.time.temporal.UnsupportedTemporalTypeException In case you choose a [TemporalUnit] which is smaller
+ *   than days.
+ *
+ * @since 3.0.0
+ */
+fun OrderedExtensionPoint.localDateFromUntil(
+	from: LocalDate,
+	toExclusive: LocalDate,
+	temporalUnit: TemporalUnit = ChronoUnit.DAYS,
+): OrderedArgsGenerator<LocalDate> =
+	LocalDateFromUntilOrderedArgsGenerator(_components, from, toExclusive, temporalUnit)
+
+/**
+ * Returns an [OrderedArgsGenerator] which generates [LocalDateTime]s ranging [from] (inclusive) to [toExclusive]
+ * where [temporalUnit] defines the steps.
+ *
+ * @throws ArithmeticException in case the difference between [from] and [toExclusive] is too big.
+ *
+ * @since 3.0.0
+ */
+fun OrderedExtensionPoint.localDateTimeFromUntil(
+	from: LocalDateTime,
+	toExclusive: LocalDateTime,
+	temporalUnit: TemporalUnit,
+): OrderedArgsGenerator<LocalDateTime> =
+	LocalDateTimeFromUntilOrderedArgsGenerator(_components, from, toExclusive, temporalUnit)
+
+/**
+ * Returns an [OrderedArgsGenerator] which generates [ZonedDateTime]s ranging [from] (inclusive) to [toExclusive]
+ * where [temporalUnit] defines the steps.
+ *
+ * @throws ArithmeticException in case the difference between [from] and [toExclusive] is too big.
+ *
+ * @since 3.0.0
+ */
+fun OrderedExtensionPoint.zonedDateTimeFromUntil(
+	from: ZonedDateTime,
+	toExclusive: ZonedDateTime,
+	temporalUnit: TemporalUnit,
+): OrderedArgsGenerator<ZonedDateTime> =
+	ZonedDateTimeFromUntilOrderedArgsGenerator(_components, from, toExclusive, temporalUnit)
+
+/**
+ * Returns an [OrderedArgsGenerator] which generates [OffsetDateTime]s ranging [from] (inclusive) to [toExclusive]
+ * where [temporalUnit] defines the steps.
+ *
+ * @throws ArithmeticException in case the difference between [from] and [toExclusive] is too big.
+ *
+ * @since 3.0.0
+ */
+fun OrderedExtensionPoint.offsetDateTimeFromUntil(
+	from: OffsetDateTime,
+	toExclusive: OffsetDateTime,
+	temporalUnit: TemporalUnit,
+): OrderedArgsGenerator<OffsetDateTime> =
+	OffsetDateTimeFromUntilOrderedArgsGenerator(_components, from, toExclusive, temporalUnit)
+
+/**
+ * Returns an [OrderedArgsGenerator] which generates [LocalTime]s ranging [from] (inclusive) to [toInclusive]
+ * where [temporalUnit] defines the steps which defaults to [ChronoUnit.SECONDS].
+ *
+ * @since 3.0.0
+ */
+fun OrderedExtensionPoint.localTimeFromTo(
+	from: LocalTime,
+	toInclusive: LocalTime,
+	temporalUnit: TemporalUnit,
+): OrderedArgsGenerator<LocalTime> =
+	LocalTimeFromToOrderedArgsGenerator(_components, from, toInclusive, temporalUnit)
+
+/**
+ * Returns an [OrderedArgsGenerator] which generates [LocalDate]s ranging [from] (inclusive) to [toInclusive]
+ * where [temporalUnit] defines the steps which defaults to [ChronoUnit.DAYS].
+ *
+ * @throws java.time.temporal.UnsupportedTemporalTypeException In case you choose a [TemporalUnit] which is smaller
+ *   than days.
+ *
+ * @since 3.0.0
+ */
+fun OrderedExtensionPoint.localDateFromTo(
+	from: LocalDate,
+	toInclusive: LocalDate,
+	temporalUnit: TemporalUnit = ChronoUnit.DAYS,
+): OrderedArgsGenerator<LocalDate> =
+	LocalDateFromToOrderedArgsGenerator(_components, from, toInclusive, temporalUnit)
+
+/**
+ * Returns an [OrderedArgsGenerator] which generates [LocalDateTime]s ranging [from] (inclusive) to [toInclusive]
+ * where [temporalUnit] defines the steps.
+ *
+ * @throws ArithmeticException in case the difference between [from] and [toInclusive] is too big.
+ *
+ * @since 3.0.0
+ */
+fun OrderedExtensionPoint.localDateTimeFromTo(
+	from: LocalDateTime,
+	toInclusive: LocalDateTime,
+	temporalUnit: TemporalUnit
+): OrderedArgsGenerator<LocalDateTime> =
+	LocalDateTimeFromToOrderedArgsGenerator(_components, from, toInclusive, temporalUnit)
+
+/**
+ * Returns an [OrderedArgsGenerator] which generates [ZonedDateTime]s ranging [from] (inclusive) to [toInclusive]
+ * where [temporalUnit] defines the steps.
+ *
+ * @throws ArithmeticException in case the difference between [from] and [toInclusive] is too big.
+ *
+ * @since 3.0.0
+ */
+fun OrderedExtensionPoint.zonedDateTimeFromTo(
+	from: ZonedDateTime,
+	toInclusive: ZonedDateTime,
+	temporalUnit: TemporalUnit,
+): OrderedArgsGenerator<ZonedDateTime> =
+	ZonedDateTimeFromToOrderedArgsGenerator(_components, from, toInclusive, temporalUnit)
+
+/**
+ * Returns an [OrderedArgsGenerator] which generates [OffsetDateTime]s ranging [from] (inclusive) to [toInclusive]
+ * where [temporalUnit] defines the steps.
+ *
+ * @throws ArithmeticException in case the difference between [from] and [toInclusive] is too big.
+ *
+ * @since 3.0.0
+ */
+fun OrderedExtensionPoint.offsetDateTimeFromTo(
+	from: OffsetDateTime,
+	toInclusive: OffsetDateTime,
+	temporalUnit: TemporalUnit,
+): OrderedArgsGenerator<OffsetDateTime> =
+	OffsetDateTimeFromToOrderedArgsGenerator(_components, from, toInclusive, temporalUnit)

--- a/src/test/kotlin/com/tegonal/variist/generators/OrderedDateLikeTest.kt
+++ b/src/test/kotlin/com/tegonal/variist/generators/OrderedDateLikeTest.kt
@@ -1,0 +1,98 @@
+package com.tegonal.variist.generators
+
+import ch.tutteli.kbox.Tuple
+import java.time.LocalTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+
+class OrderedDateLikeTest : AbstractOrderedArgsGeneratorTest<Any>() {
+
+	override fun createGenerators(modifiedOrdered: OrderedExtensionPoint) = run {
+		val zoneOffset = ZoneOffset.ofHours(1)
+		val nowZonedDateTime = ZonedDateTime.now().truncatedTo(ChronoUnit.HOURS)
+		val nowLocalDateTime = nowZonedDateTime.toLocalDateTime()
+		val nowLocalTime = nowZonedDateTime.toLocalTime().let {
+			if (it.plusHours(2) >= LocalTime.of(0, 0)) LocalTime.of(21, 0) else it
+		}
+		val nowLocalDate = nowZonedDateTime.toLocalDate()
+		val nowOffsetDateTime = nowZonedDateTime.toOffsetDateTime().withOffsetSameInstant(zoneOffset)
+		sequenceOf(
+			Tuple(
+				"localTimeFromUntil",
+				modifiedOrdered.localTimeFromUntil(nowLocalTime, nowLocalTime.plusHours(2), ChronoUnit.HOURS),
+				listOf(nowLocalTime, nowLocalTime.plusHours(1))
+			),
+			Tuple(
+				"localDateFromUntil",
+				modifiedOrdered.localDateFromUntil(nowLocalDate, nowLocalDate.plusDays(2), ChronoUnit.DAYS),
+				listOf(nowLocalDate, nowLocalDate.plusDays(1))
+			),
+			Tuple(
+				"localDateTimeFromUntil",
+				modifiedOrdered.localDateTimeFromUntil(
+					nowLocalDateTime,
+					nowLocalDateTime.plusDays(1),
+					ChronoUnit.HOURS
+				),
+				(0L..23).map { nowLocalDateTime.plusHours(it) }
+			),
+			Tuple(
+				"zonedDateTimeFromUntil",
+				modifiedOrdered.zonedDateTimeFromUntil(
+					nowZonedDateTime,
+					nowZonedDateTime.plusHours(3),
+					ChronoUnit.MINUTES,
+				),
+				(0L until 3 * 60).map { nowZonedDateTime.plusMinutes(it) }
+			),
+
+			Tuple(
+				"offsetDateTimeFromUntil",
+				modifiedOrdered.offsetDateTimeFromUntil(
+					nowOffsetDateTime,
+					nowOffsetDateTime.plusMinutes(2),
+					ChronoUnit.SECONDS,
+				),
+				(0L until 2 * 60).map { nowOffsetDateTime.plusSeconds(it) }
+			),
+			Tuple(
+				"localTimeFromTo",
+				modifiedOrdered.localTimeFromTo(nowLocalTime, nowLocalTime.plusMinutes(2), ChronoUnit.MINUTES),
+				listOf(nowLocalTime, nowLocalTime.plusMinutes(1), nowLocalTime.plusMinutes(2))
+			),
+			Tuple(
+				"localDateFromTo",
+				modifiedOrdered.localDateFromTo(nowLocalDate, nowLocalDate.plusDays(2), ChronoUnit.DAYS),
+				listOf(nowLocalDate, nowLocalDate.plusDays(1), nowLocalDate.plusDays(2))
+			),
+			Tuple(
+				"localDateTimeFromTo",
+				modifiedOrdered.localDateTimeFromTo(
+					nowLocalDateTime,
+					nowLocalDateTime.plus(13, ChronoUnit.MILLIS),
+					ChronoUnit.MILLIS
+				),
+				(0L..13).map { nowLocalDateTime.plus(it, ChronoUnit.MILLIS) }
+			),
+			Tuple(
+				"zonedDateTimeFromTo",
+				modifiedOrdered.zonedDateTimeFromTo(
+					nowZonedDateTime,
+					nowZonedDateTime.plus(11, ChronoUnit.MICROS),
+					ChronoUnit.MICROS,
+				),
+				(0L..11).map { nowZonedDateTime.plus(it, ChronoUnit.MICROS) }
+			),
+			Tuple(
+				"offsetDateTimeFromTo",
+				modifiedOrdered.offsetDateTimeFromTo(
+					nowOffsetDateTime,
+					nowOffsetDateTime.plusMinutes(1),
+					ChronoUnit.SECONDS,
+				),
+				(0L..1 * 60).map { nowOffsetDateTime.plusSeconds(it) }
+			),
+		)
+	}
+}


### PR DESCRIPTION
those generators can quickly overflow if the units are too small. We assume users will use arb.dateLike if the generator generates to many values, i.e. chooses the range wisely if using ordered and thus don't add any extra checks



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/variist/blob/main/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
